### PR TITLE
Add static tf to planning scene

### DIFF
--- a/benchmark_suite/CMakeLists.txt
+++ b/benchmark_suite/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(Eigen3 REQUIRED)
 find_package(fcl REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
+  tf2_ros
   eigen_conversions
   geometric_shapes
   geometry_msgs
@@ -27,6 +28,7 @@ catkin_package(
   INCLUDE_DIRS
     include
   CATKIN_DEPENDS
+    tf2_ros
     geometric_shapes
     geometry_msgs
     moveit_core

--- a/benchmark_suite/include/moveit_benchmark_suite/scene.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/scene.h
@@ -46,4 +46,10 @@ private:
   std::map<std::string, collision_detection::CollisionPluginPtr> plugins_;  ///< Loaded plugins.
 };
 
+void getTransformsFromTf(std::vector<geometry_msgs::TransformStamped>& transforms,
+                         const robot_model::RobotModelConstPtr& rm);
+
+void addTransformsToSceneMsg(const std::vector<geometry_msgs::TransformStamped>& transforms,
+                             moveit_msgs::PlanningScene& scene_msg);
+
 }  // namespace moveit_benchmark_suite

--- a/benchmark_suite/package.xml
+++ b/benchmark_suite/package.xml
@@ -9,8 +9,8 @@
 	<buildtool_depend>catkin</buildtool_depend>
 
 	<depend>boost</depend>
+	<depend>tf2_ros</depend>
 	<depend>yaml-cpp</depend>
-
 	<depend>geometric_shapes</depend>
 	<depend>geometry_msgs</depend>
 	<depend>eigen_conversions</depend>

--- a/benchmark_suite/src/benchmarks/motion_planning.cpp
+++ b/benchmark_suite/src/benchmarks/motion_planning.cpp
@@ -61,6 +61,14 @@ int main(int argc, char** argv)
 
   ros::NodeHandle pnh("~");
 
+  // Setup robot
+  auto robot = std::make_shared<Robot>("robot", "robot_description");
+  robot->initialize();
+
+  // Get transforms from tf listener
+  std::vector<geometry_msgs::TransformStamped> transforms;
+  getTransformsFromTf(transforms, robot->getModelConst());
+
   // Prepare query setup
   QuerySetup query_setup;
 
@@ -92,6 +100,9 @@ int main(int argc, char** argv)
     scene_msgs.back().is_diff = true;
     parser.getCollisionObjects(scene_msgs.back().world.collision_objects);
 
+    // If tf add it to the planning scene
+    addTransformsToSceneMsg(transforms, scene_msgs.back());
+
     query_setup.addQuery("scene", scene.first, "");
   }
 
@@ -120,10 +131,6 @@ int main(int argc, char** argv)
   const std::set<std::string>& collision_detectors = config.getCollisionDetectors();
   const std::map<std::string, std::vector<std::string>>& planning_pipelines =
       config.getPlanningPipelineConfigurations();
-
-  // Setup robot
-  auto robot = std::make_shared<Robot>("robot", "robot_description");
-  robot->initialize();
 
   // Setup scenes
   std::vector<planning_scene::PlanningScenePtr> scenes;


### PR DESCRIPTION
This PR resolves #9 by subscribing to the `/tf_static` topic and by adding it to the PlanningScene `fixed_frame_transforms` field.

#### Caveat
- When multiple tf are included in the `fixed_frame_transforms`, some frames triggers an error.
```bash
[ERROR] [1631215385.714685866]: Given transform is to frame 'panda_hand', but frame 'panda_link0' was expected.
[ERROR] [1631215385.714727137]: Given transform is to frame 'panda_link8', but frame 'panda_link0' was expected.
```
- We should add a timeout to be sure that the node has time to get `/tf_static` from all subscribers. But this would be slow down the benchmark...

#### Reflexion
- Tried getting the tf from the tf2_listener without success by following this [tutorial](http://wiki.ros.org/tf2/Tutorials/Writing%20a%20tf2%20listener%20%28C%2B%2B%29).
- There must be a simplier way ?