### PR TITLE
WIP: Refactor world frame retrieval

### DIFF
--- a/benchmark_suite/include/moveit_benchmark_suite/scene.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/scene.h
@@ -46,10 +46,7 @@ private:
   std::map<std::string, collision_detection::CollisionPluginPtr> plugins_;  ///< Loaded plugins.
 };
 
-void getTransformsFromTf(std::vector<geometry_msgs::TransformStamped>& transforms,
-                         const robot_model::RobotModelConstPtr& rm);
-
-void addTransformsToSceneMsg(const std::vector<geometry_msgs::TransformStamped>& transforms,
-                             moveit_msgs::PlanningScene& scene_msg);
+void getVirtualModelTransform(std::vector<geometry_msgs::TransformStamped>& transforms,
+                              const robot_model::RobotModelConstPtr& robot, double timeout);
 
 }  // namespace moveit_benchmark_suite

--- a/benchmark_suite/src/benchmarks/motion_planning.cpp
+++ b/benchmark_suite/src/benchmarks/motion_planning.cpp
@@ -65,9 +65,9 @@ int main(int argc, char** argv)
   auto robot = std::make_shared<Robot>("robot", "robot_description");
   robot->initialize();
 
-  // Get transforms from tf listener
+  // Get virtual transforms from robot model or tf listener
   std::vector<geometry_msgs::TransformStamped> transforms;
-  getTransformsFromTf(transforms, robot->getModelConst());
+  getVirtualModelTransform(transforms, robot->getModelConst(), 1.0);
 
   // Prepare query setup
   QuerySetup query_setup;
@@ -100,8 +100,9 @@ int main(int argc, char** argv)
     scene_msgs.back().is_diff = true;
     parser.getCollisionObjects(scene_msgs.back().world.collision_objects);
 
-    // If tf add it to the planning scene
-    addTransformsToSceneMsg(transforms, scene_msgs.back());
+    // Add virtual transform
+    for (const auto& transform : transforms)
+      scene_msgs.back().fixed_frame_transforms.push_back(transform);
 
     query_setup.addQuery("scene", scene.first, "");
   }


### PR DESCRIPTION
In PR #10, a way to retrieve a static tf was added. This one aims to reduce the waiting time if the virtual joint parent tf is present by skipping the tf retrieval.

This needs to be discussed and their maybe changes with MoveIt soon.