### PR TITLE
Generate HTML file with embedded SVG pictures

### DIFF
--- a/.docs/benchmarks/motion_planning.md
+++ b/.docs/benchmarks/motion_planning.md
@@ -40,7 +40,7 @@ The robot, scenes and requests are configured in the [motion_planning_pp.launch]
 </launch>
 
 ```
-**Note:** Unlike the `PlanningPipeline``, you can't benchmark multiple collision detectors in one pass with the `MoveGroupInterface`.
+**Note:** Unlike the `PlanningPipeline`, you can't benchmark multiple collision detectors in one pass with the `MoveGroupInterface`.
 
 A request is a `moveit_msgs/MotionPlanRequest.msg`. Only these field are required:
 ```yaml
@@ -88,4 +88,4 @@ benchmark_config:
       planners:
         - STOMP
 ```
-**Note:** The `MoveGroupInterface` has the `collision_detector` parameter in the yaml file.
+**Note:** The `MoveGroupInterface` has the singular `collision_detector` parameter.

--- a/benchmark_suite/CMakeLists.txt
+++ b/benchmark_suite/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(${PROJECT_NAME}
   src/planning.cpp
   src/trajectory.cpp
   src/io/handler.cpp
+  src/io/htmlplot.cpp
   src/io/gnuplot.cpp
   src/config/aggregate_config.cpp
   src/config/gnuplot_config.cpp

--- a/benchmark_suite/CMakeLists.txt
+++ b/benchmark_suite/CMakeLists.txt
@@ -87,6 +87,9 @@ target_link_libraries(plot_dataset ${PROJECT_NAME} ${catkin_LIBRARIES} yaml-cpp)
 add_executable(aggregate src/aggregate.cpp)
 target_link_libraries(aggregate ${PROJECT_NAME} ${catkin_LIBRARIES} yaml-cpp)
 
+add_executable(generate_plots src/generate_plots.cpp)
+target_link_libraries(generate_plots ${PROJECT_NAME} ${catkin_LIBRARIES} yaml-cpp)
+
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
@@ -96,6 +99,7 @@ install(TARGETS
   motion_planning_pp
   collision_check
   plot_dataset
+  generate_plots
   aggregate
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/benchmark_suite/CMakeLists.txt
+++ b/benchmark_suite/CMakeLists.txt
@@ -64,6 +64,7 @@ add_library(${PROJECT_NAME}
   src/io/gnuplot.cpp
   src/config/aggregate_config.cpp
   src/config/gnuplot_config.cpp
+  src/config/html_config.cpp
   src/config/motion_planning_config.cpp
   src/benchmarks/builder/motion_planning.cpp
   src/benchmarks/motion_planning_benchmark.cpp

--- a/benchmark_suite/config/plots.yaml
+++ b/benchmark_suite/config/plots.yaml
@@ -1,0 +1,12 @@
+html_config:
+  # PP vs MGI time of RRTConnect over all scenes
+  - title: PP vs MGI
+    legend_filters:
+      - type/MOTION PLANNING PP
+      - type/MOTION PLANNING MGI
+    xtick_filters:
+      - config/scene/
+      - config/planner/RRTConnect
+      - config/collision_detector/FCL
+    metrics:
+      - time: boxplot

--- a/benchmark_suite/config/plots.yaml
+++ b/benchmark_suite/config/plots.yaml
@@ -10,3 +10,82 @@ html_config:
       - config/collision_detector/FCL
     metrics:
       - time: boxplot
+
+  # Scenes & goal constraints
+  - title: Scenes & goal constraints
+    legend_filters:
+      - type/MOTION PLANNING PP
+      - config/scene/
+    xtick_filters:
+      - config/planner/RRTConnect
+      #- config/planner/BST
+      - config/collision_detector/FCL
+    metrics:
+      - time: boxplot
+      - avg_success: bargraph
+      - avg_correct: bargraph
+
+  - title: Planners vs Scenes
+    legend_filters:
+      - type/MOTION PLANNING PP
+      - config/scene/
+    xtick_filters:
+      - config/planner/
+      - config/collision_detector/FCL
+      - config/request/jc
+      - config/pipeline/ompl
+    metrics:
+      - time: boxplot
+      - avg_success: bargraph
+      - avg_correct: bargraph
+
+  - title: Planners vs Collision Detectors
+    legend_filters:
+      - type/MOTION PLANNING PP
+      - config/collision_detector/
+    xtick_filters:
+      - config/scene/bbt-mesh
+      - config/planner/
+      - config/request/jc
+      - config/pipeline/ompl
+    metrics:
+      - time: boxplot
+      - avg_success: bargraph
+      - avg_correct: bargraph
+
+  - title: Planners vs Collision Detectors
+    legend_filters:
+      - type/MOTION PLANNING PP
+      - config/collision_detector/
+    xtick_filters:
+      - config/scene/bbt-primitive
+      - config/planner/
+      - config/request/jc
+      - config/pipeline/ompl
+    metrics:
+      - time: boxplot
+      - avg_success: bargraph
+      - avg_correct: bargraph
+
+  - title: Planners vs Collision Detectors
+    legend_filters:
+      - type/MOTION PLANNING PP
+      - config/collision_detector/
+    xtick_filters:
+      - config/scene/empty-scene
+      - config/planner/
+      - config/request/jc
+      - config/pipeline/ompl
+    metrics:
+      - time: boxplot
+      - avg_success: bargraph
+      - avg_correct: bargraph
+
+aggregate_config:
+  aggregate:
+    - raw_metric: success
+      new_metric: avg_success
+      type: average
+    - raw_metric: correct
+      new_metric: avg_correct
+      type: average

--- a/benchmark_suite/include/moveit_benchmark_suite/config/html_config.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/config/html_config.h
@@ -1,0 +1,83 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: Parse HTML configuration from ros param server
+*/
+
+#pragma once
+
+#include <ros/node_handle.h>
+
+namespace moveit_benchmark_suite
+{
+struct HTMLConfigMetric
+{
+  std::string name;
+  std::string type;
+};
+
+struct HTMLConfigStruct
+{
+  std::string title;
+  std::vector<std::string> legends;
+  std::vector<std::string> xticks;
+
+  std::vector<HTMLConfigMetric> metrics;
+};
+
+class HTMLConfig
+{
+public:
+  /** \brief Constructor */
+  HTMLConfig();
+  /** \brief Constructor accepting a custom namespace for parameter lookup */
+  HTMLConfig(const std::string& ros_namespace);
+  /** \brief Destructor */
+  virtual ~HTMLConfig();
+
+  /** \brief Set the ROS namespace the node handle should use for parameter lookup */
+  void setNamespace(const std::string& ros_namespace);
+
+  const std::vector<HTMLConfigStruct>& getConfig() const;
+
+  bool isConfigAvailable(const std::string& ros_namespace);
+
+protected:
+  void readConfig(const std::string& ros_namespace);
+
+  std::vector<HTMLConfigStruct> configs_;
+};
+
+}  // namespace moveit_benchmark_suite

--- a/benchmark_suite/include/moveit_benchmark_suite/dataset.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/dataset.h
@@ -215,6 +215,8 @@ public:
   void eraseMetric(const std::string& metric);
 
   std::vector<DataPtr> getFlatData() const;
+
+  std::set<std::string> getMetricNames();
 };
 
 class Profiler

--- a/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
@@ -208,7 +208,7 @@ private:
 
 #if IS_BOOST_164
     boost::process::opstream input_;
-    // boost::process::ipstream output_;
+    boost::process::ipstream output_;
     boost::process::ipstream error_;
     boost::process::child gnuplot_;
 #endif

--- a/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
@@ -199,6 +199,9 @@ private:
 
     /** \} */
 
+    boost::process::ipstream& getOutput();
+    boost::process::ipstream& getError();
+
   private:
     // non-copyable
     Instance(Instance const&) = delete;

--- a/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
@@ -269,6 +269,8 @@ public:
   void dump(const std::vector<DataSetPtr>& datasets, const GNUPlotTerminal& terminal,
             const GNUPlotHelper::MultiPlotOptions& mpo, const TokenSet& xtick_set, const TokenSet& legend_set = {});
 
+  GNUPlotHelper& getGNUPlotHelper();
+
 private:
   void dumpBoxPlot(const std::string& metric, const std::vector<DataSetPtr>& results, const TokenSet& xtick_set,
                    const TokenSet& legend_set);

--- a/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
@@ -18,6 +18,46 @@ namespace moveit_benchmark_suite
 {
 namespace IO
 {
+static std::string TERMINAL_QT_STR = "qt";
+
+struct TerminalSize
+{
+  double x = 640;
+  double y = 480;
+};
+
+/** \brief An abstract class for GNUPlot terminal. */
+class GNUPlotTerminal
+{
+public:
+  GNUPlotTerminal(const std::string& mode);
+
+  /** \brief Virtual destructor for cleaning up resources.
+   */
+  virtual ~GNUPlotTerminal() = default;
+
+  // Get GNUPlot command as a string
+  virtual std::string getCmd() const = 0;
+
+  const std::string mode;
+};
+
+// Generates output in a separate window with the Qt library
+class QtTerminal : public GNUPlotTerminal
+{
+public:
+  QtTerminal();
+  QtTerminal(const TerminalSize& size);
+  /** \brief Virtual destructor for cleaning up resources.
+   */
+  ~QtTerminal() override;
+
+  // Get GNUPlot command as a string
+  std::string getCmd() const override;
+
+  TerminalSize size = { .x = 640, .y = 480 };
+};
+
 /** \brief Helper class to open a pipe to a GNUPlot instance for live visualization of data.
  */
 class GNUPlotHelper
@@ -43,20 +83,7 @@ public:
     std::string instance{ "default" };
   };
 
-  struct QtTerminalOptions : InstanceOptions
-  {
-    struct Size
-    {
-      double x = 720;
-      double y = 480;
-    };
-
-    Size size;
-
-    const std::string mode{ "qt" };  ///< Terminal mode for GNUPlot
-  };
-
-  void configureTerminal(const QtTerminalOptions& options);
+  void configureTerminal(const std::string& instance_id, const GNUPlotTerminal& terminal);
 
   /** \name Plotting
       \{ */
@@ -208,10 +235,10 @@ public:
   void addMetric(const std::string& metric, const PlotType& plottype);
   void addMetric(const std::string& metric, const std::string& plottype);
 
-  void dump(const DataSetPtr& dataset, const GNUPlotHelper::MultiPlotOptions& mpo, const TokenSet& xtick_set,
-            const TokenSet& legend_set = {});
-  void dump(const std::vector<DataSetPtr>& datasets, const GNUPlotHelper::MultiPlotOptions& mpo,
+  void dump(const DataSetPtr& dataset, const GNUPlotTerminal& terminal, const GNUPlotHelper::MultiPlotOptions& mpo,
             const TokenSet& xtick_set, const TokenSet& legend_set = {});
+  void dump(const std::vector<DataSetPtr>& datasets, const GNUPlotTerminal& terminal,
+            const GNUPlotHelper::MultiPlotOptions& mpo, const TokenSet& xtick_set, const TokenSet& legend_set = {});
 
 private:
   void dumpBoxPlot(const std::string& metric, const std::vector<DataSetPtr>& results, const TokenSet& xtick_set,

--- a/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
@@ -12,6 +12,7 @@
 
 #if IS_BOOST_164
 #include <boost/process.hpp>
+#include <boost/asio/io_service.hpp>
 #endif
 
 namespace moveit_benchmark_suite
@@ -99,6 +100,9 @@ public:
   {
     std::string instance{ "default" };
   };
+
+  std::set<std::string> getInstanceNames() const;
+  void getInstanceOutput(const std::string& instance, std::string& output);
 
   void configureTerminal(const std::string& instance_id, const GNUPlotTerminal& terminal);
 
@@ -190,6 +194,8 @@ private:
      */
     Instance();
 
+    ~Instance();
+
     /** \name Raw Input
         \{ */
 
@@ -199,8 +205,8 @@ private:
 
     /** \} */
 
-    boost::process::ipstream& getOutput();
-    boost::process::ipstream& getError();
+    std::shared_ptr<std::future<std::vector<char>>> getOutput();
+    std::shared_ptr<std::future<std::vector<char>>> getError();
 
   private:
     // non-copyable
@@ -209,10 +215,13 @@ private:
 
     bool debug_{ false };
 
+    boost::asio::io_service svc_;
+    std::thread th_;
+
 #if IS_BOOST_164
     boost::process::opstream input_;
-    boost::process::ipstream output_;
-    boost::process::ipstream error_;
+    std::shared_ptr<std::future<std::vector<char>>> output_ = std::make_shared<std::future<std::vector<char>>>();
+    std::shared_ptr<std::future<std::vector<char>>> error_ = std::make_shared<std::future<std::vector<char>>>();
     boost::process::child gnuplot_;
 #endif
   };

--- a/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
@@ -19,6 +19,7 @@ namespace moveit_benchmark_suite
 namespace IO
 {
 static std::string TERMINAL_QT_STR = "qt";
+static std::string TERMINAL_SVG_STR = "svg";
 
 struct TerminalSize
 {
@@ -51,6 +52,22 @@ public:
   /** \brief Virtual destructor for cleaning up resources.
    */
   ~QtTerminal() override;
+
+  // Get GNUPlot command as a string
+  std::string getCmd() const override;
+
+  TerminalSize size = { .x = 640, .y = 480 };
+};
+
+// Produces files in the W3C Scalable Vector Graphics format
+class SvgTerminal : public GNUPlotTerminal
+{
+public:
+  SvgTerminal();
+  SvgTerminal(const TerminalSize& size);
+  /** \brief Virtual destructor for cleaning up resources.
+   */
+  ~SvgTerminal() override;
 
   // Get GNUPlot command as a string
   std::string getCmd() const override;

--- a/benchmark_suite/include/moveit_benchmark_suite/io/htmlplot.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/io/htmlplot.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+#include <fstream>
+
+namespace moveit_benchmark_suite
+{
+namespace IO
+{
+class HTMLPlot
+{
+public:
+  HTMLPlot();
+
+  void write(const std::string& line);
+  void writeline(const std::string& line);
+  void flush();
+
+  void dump();
+
+private:
+  std::ofstream output_;
+  std::string out_filepath;
+  std::string out_filename;
+};
+
+}  // namespace IO
+}  // namespace moveit_benchmark_suite

--- a/benchmark_suite/include/moveit_benchmark_suite/token.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/token.h
@@ -61,6 +61,7 @@ struct Token
   void reset();
 
   std::string token;
+  std::string group;
   std::string value;
   std::string del;
 

--- a/benchmark_suite/launch/generate_plots.launch
+++ b/benchmark_suite/launch/generate_plots.launch
@@ -8,9 +8,14 @@
   <arg unless="$(arg debug)" name="launch_prefix" value="" />
   <arg     if="$(arg debug)" name="launch_prefix" value="gdb --args" />
 
+
+  <!-- Generate Plots options file -->
+  <arg name="options_file" default="$(find moveit_benchmark_suite)/config/plots.yaml"/>
+
+  <!-- Launch plot generator node -->
   <node name="generate_plots" pkg="moveit_benchmark_suite" type="generate_plots" respawn="false" clear_params="true" required="true" output="screen" launch-prefix="$(arg launch_prefix)">
-
-  <rosparam param="input_files" subst_value="True">$(arg input_files)</rosparam>
-
+    <rosparam command="load" file="$(arg options_file)"/>
+    <rosparam param="input_files" subst_value="True">$(arg input_files)</rosparam>
   </node>
+
 </launch>

--- a/benchmark_suite/launch/generate_plots.launch
+++ b/benchmark_suite/launch/generate_plots.launch
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+<launch>
+
+  <arg name="input_files" default="[]"/>
+
+  <!-- By default, we are not in debug mode -->
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value="" />
+  <arg     if="$(arg debug)" name="launch_prefix" value="gdb --args" />
+
+  <node name="generate_plots" pkg="moveit_benchmark_suite" type="generate_plots" respawn="false" clear_params="true" required="true" output="screen" launch-prefix="$(arg launch_prefix)">
+
+  <rosparam param="input_files" subst_value="True">$(arg input_files)</rosparam>
+
+  </node>
+</launch>

--- a/benchmark_suite/src/benchmark.cpp
+++ b/benchmark_suite/src/benchmark.cpp
@@ -66,11 +66,14 @@ Benchmark::Benchmark(const std::string& name,  //
     for (const auto& metric : metrics)
       plot.addMetric(metric.name, metric.type);
 
+    IO::QtTerminal terminal;
+
     IO::GNUPlotHelper::MultiPlotOptions mpo;
     mpo.layout.row = option.n_row;
     mpo.layout.col = option.n_col;
 
-    addPostBenchmarkCallback([=](DataSetPtr dataset) { plot.dump(dataset, mpo, xtick_filters, legend_filters); });
+    addPostBenchmarkCallback(
+        [=](DataSetPtr dataset) { plot.dump(dataset, terminal, mpo, xtick_filters, legend_filters); });
   }
 };
 

--- a/benchmark_suite/src/benchmarks/node/collision_check.cpp
+++ b/benchmark_suite/src/benchmarks/node/collision_check.cpp
@@ -212,6 +212,8 @@ int main(int argc, char** argv)
   plot.addMetric("time", IO::GNUPlotDataSet::BoxPlot);
   plot.addMetric("collision_checks_per_second", IO::GNUPlotDataSet::BarGraph);
 
+  IO::QtTerminal terminal;
+
   IO::GNUPlotHelper::MultiPlotOptions mpo;
   mpo.layout.row = 2;
   mpo.layout.col = 1;
@@ -225,7 +227,7 @@ int main(int argc, char** argv)
   legend.insert(Token("query_setup/collision_detector", "Bullet"));
   // legend_set.insert(Token("hardware/cpu/vendor_id", ""));
 
-  plot.dump(dataset, mpo, xtick, legend);
+  plot.dump(dataset, terminal, mpo, xtick, legend);
 
   // Dump metrics to a logfile
   BenchmarkSuiteDataSetOutputter output;

--- a/benchmark_suite/src/config/html_config.cpp
+++ b/benchmark_suite/src/config/html_config.cpp
@@ -1,0 +1,99 @@
+
+
+#include <moveit_benchmark_suite/config/html_config.h>
+
+using namespace moveit_benchmark_suite;
+
+///
+/// HTMLConfig
+///
+
+HTMLConfig::HTMLConfig()
+{
+}
+
+HTMLConfig::HTMLConfig(const std::string& ros_namespace)
+{
+  readConfig(ros_namespace);
+}
+
+HTMLConfig::~HTMLConfig() = default;
+
+bool HTMLConfig::isConfigAvailable(const std::string& ros_namespace)
+{
+  ros::NodeHandle nh(ros_namespace);
+
+  if (nh.hasParam("html_config"))
+    return true;
+  return false;
+}
+
+void HTMLConfig::setNamespace(const std::string& ros_namespace)
+{
+  readConfig(ros_namespace);
+}
+const std::vector<HTMLConfigStruct>& HTMLConfig::getConfig() const
+{
+  return configs_;
+}
+
+void HTMLConfig::readConfig(const std::string& ros_namespace)
+{
+  ros::NodeHandle nh(ros_namespace);
+
+  XmlRpc::XmlRpcValue html_node;
+  if (nh.getParam("html_config", html_node))
+  {
+    ROS_ASSERT(html_node.getType() == XmlRpc::XmlRpcValue::TypeArray);
+    for (int i = 0; i < html_node.size(); ++i)
+    {
+      HTMLConfigStruct config;
+      ROS_ASSERT(html_node[i].getType() == XmlRpc::XmlRpcValue::TypeStruct);
+
+      if (html_node[i].hasMember("title"))
+        config.title = static_cast<std::string>(html_node[i]["title"]);
+
+      if (html_node[i].hasMember("legend_filters"))
+      {
+        auto& filters = html_node[i]["legend_filters"];
+        ROS_ASSERT(filters.getType() == XmlRpc::XmlRpcValue::TypeArray);
+
+        for (int j = 0; j < filters.size(); ++j)
+        {
+          std::string value = static_cast<std::string>(filters[j]);
+          config.legends.push_back(value);
+        }
+      }
+
+      if (html_node[i].hasMember("xtick_filters"))
+      {
+        auto& filters = html_node[i]["xtick_filters"];
+        ROS_ASSERT(filters.getType() == XmlRpc::XmlRpcValue::TypeArray);
+
+        for (int j = 0; j < filters.size(); ++j)
+        {
+          std::string value = static_cast<std::string>(filters[j]);
+          config.xticks.push_back(value);
+        }
+      }
+
+      if (html_node[i].hasMember("metrics"))
+      {
+        auto& metrics = html_node[i]["metrics"];
+        ROS_ASSERT(metrics.getType() == XmlRpc::XmlRpcValue::TypeArray);
+
+        for (int j = 0; j < metrics.size(); ++j)
+        {
+          HTMLConfigMetric metric;
+
+          metric.name = static_cast<std::string>(metrics[j].begin()->first);
+          metric.type = static_cast<std::string>(metrics[j].begin()->second);
+          config.metrics.push_back(metric);
+        }
+      }
+      configs_.push_back(config);
+    }
+  }
+  else
+    ROS_WARN("No 'html_config' found on param server");
+}

--- a/benchmark_suite/src/dataset.cpp
+++ b/benchmark_suite/src/dataset.cpp
@@ -106,6 +106,19 @@ std::vector<DataPtr> DataSet::getFlatData() const
   return r;
 }
 
+std::set<std::string> DataSet::getMetricNames()
+{
+  std::set<std::string> names;
+
+  if (data.empty() || data.begin()->second.empty())
+    return names;
+
+  for (const auto& metric_map : data.begin()->second[0]->metrics)
+    names.insert(metric_map.first);
+
+  return names;
+}
+
 void DataSet::eraseMetric(const std::string& metric)
 {
   for (const auto& data_map : data)

--- a/benchmark_suite/src/generate_plots.cpp
+++ b/benchmark_suite/src/generate_plots.cpp
@@ -55,34 +55,111 @@ int main(int argc, char** argv)
       TokenSet legend;
       legend.insert(Token("config/" + config.first + "/"));
 
-      for (const auto& metric_name : dataset->getMetricNames())
-      {
-        // Plot metric to GNUPlot SVG terminal -> std::output
-        IO::GNUPlotDataSet plot;
+      if (config.second.size() <= 1)
+        continue;
 
-        // Skip some impractical metrics
-        if (metric_name.compare("process_id") == 0 || metric_name.compare("thread_id") == 0)
+      std::map<std::string, std::set<std::string>> xlabel_map;
+
+      for (const auto& config_ : dataset->query_setup.query_setup)
+      {
+        if (config_.first.compare(config.first) == 0)
           continue;
 
-        if (metric_name.rfind("avg", 0) == 0)
-          plot.addMetric(metric_name, IO::GNUPlotDataSet::PlotType::BarGraph);
-        else
-          plot.addMetric(metric_name, IO::GNUPlotDataSet::PlotType::BoxPlot);
-
-        IO::SvgTerminal terminal;
-        IO::GNUPlotHelper::MultiPlotOptions mpo;
-
-        plot.dump(datasets, terminal, mpo, xtick, legend);
-
-        // Get terminal stream SVG (XML format)
-        IO::GNUPlotHelper& helper = plot.getGNUPlotHelper();
-        std::set<std::string> instance_names = helper.getInstanceNames();
-
-        std::string output;
-        for (const auto& ins_name : instance_names)
+        for (const auto& test : config_.second)
         {
-          helper.getInstanceOutput(ins_name, output);  // Get SVG stream
-          html.writeline(output);
+          auto it = xlabel_map.find(config_.first);
+          if (it == xlabel_map.end())
+            xlabel_map.insert({ config_.first, { test.first } });
+          else
+            it->second.insert(test.first);
+        }
+      }
+
+      struct Pair
+      {
+        std::string group;
+        std::string value;
+      };
+
+      std::vector<std::vector<Pair>> container;
+
+      for (const auto& first : xlabel_map)
+      {
+        if (container.empty())
+        {
+          for (const auto& second : first.second)
+          {
+            Pair pair = { .group = first.first, .value = second };
+            container.push_back({ pair });
+          }
+        }
+        else
+        {
+          int i = 0;
+          int ctn_size = container.size();
+          for (const auto& second : first.second)
+          {
+            auto c_ = container;
+
+            // enlarge container
+            if (i != 0)
+            {
+              for (int j = 0; j < ctn_size; ++j)
+              {
+                container.emplace_back();
+                container.back() = c_[j];
+                container.back().pop_back();
+              }
+            }
+
+            for (int j = 0; j < ctn_size; ++j)
+            {
+              Pair pair = { .group = first.first, .value = second };
+
+              container[ctn_size * i + j].push_back(pair);
+            }
+            i++;
+          }
+        }
+      }
+
+      for (const auto& c : container)
+      {
+        xtick.clear();
+        for (const auto& a : c)
+        {
+          xtick.insert(Token("config/" + a.group + "/" + a.value));
+        }
+
+        for (const auto& metric_name : dataset->getMetricNames())
+        {
+          // Plot metric to GNUPlot SVG terminal -> std::output
+          IO::GNUPlotDataSet plot;
+
+          // Skip some impractical metrics
+          if (metric_name.compare("process_id") == 0 || metric_name.compare("thread_id") == 0)
+            continue;
+
+          if (metric_name.rfind("avg", 0) == 0)
+            plot.addMetric(metric_name, IO::GNUPlotDataSet::PlotType::BarGraph);
+          else
+            plot.addMetric(metric_name, IO::GNUPlotDataSet::PlotType::BoxPlot);
+
+          IO::SvgTerminal terminal;
+          IO::GNUPlotHelper::MultiPlotOptions mpo;
+
+          plot.dump(datasets, terminal, mpo, xtick, legend);
+
+          // Get terminal stream SVG (XML format)
+          IO::GNUPlotHelper& helper = plot.getGNUPlotHelper();
+          std::set<std::string> instance_names = helper.getInstanceNames();
+
+          std::string output;
+          for (const auto& ins_name : instance_names)
+          {
+            helper.getInstanceOutput(ins_name, output);  // Get SVG stream
+            html.writeline(output);
+          }
         }
       }
     }

--- a/benchmark_suite/src/generate_plots.cpp
+++ b/benchmark_suite/src/generate_plots.cpp
@@ -1,0 +1,94 @@
+
+#include <ros/ros.h>
+#include <moveit_benchmark_suite/io/gnuplot.h>
+#include <moveit_benchmark_suite/io/htmlplot.h>
+#include <moveit_benchmark_suite/yaml.h>
+#include <moveit_benchmark_suite/benchmark.h>
+
+using namespace moveit_benchmark_suite;
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "generate_plots");
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+
+  ros::NodeHandle pnh("~");
+
+  // Parse input file
+  std::vector<std::string> files;
+  pnh.getParam("input_files", files);
+
+  // Load datasets from file
+  std::vector<DataSetPtr> datasets;
+  for (const auto& file : files)
+  {
+    std::string abs_file = IO::getAbsDataSetFile(file);
+
+    try
+    {
+      auto node = YAML::LoadFile(abs_file);
+      for (YAML::const_iterator it = node.begin(); it != node.end(); ++it)
+        datasets.push_back(std::make_shared<DataSet>(it->as<DataSet>()));
+    }
+    catch (const YAML::BadFile& e)
+    {
+      ROS_FATAL_STREAM("Specified input file '" << abs_file << "' does not exist.");
+      return 1;
+    }
+  }
+
+  if (datasets.empty())
+  {
+    ROS_WARN_STREAM(log::format("No datasets loaded from files"));
+    return 0;
+  }
+
+  // Generate plots to HTML
+  IO::HTMLPlot html;
+  for (const auto& dataset : datasets)
+  {
+    for (const auto& config : dataset->query_setup.query_setup)
+    {
+      TokenSet xtick;
+
+      TokenSet legend;
+      legend.insert(Token("config/" + config.first + "/"));
+
+      for (const auto& metric_name : dataset->getMetricNames())
+      {
+        // Plot metric to GNUPlot SVG terminal -> std::output
+        IO::GNUPlotDataSet plot;
+
+        // Skip some impractical metrics
+        if (metric_name.compare("process_id") == 0 || metric_name.compare("thread_id") == 0)
+          continue;
+
+        if (metric_name.rfind("avg", 0) == 0)
+          plot.addMetric(metric_name, IO::GNUPlotDataSet::PlotType::BarGraph);
+        else
+          plot.addMetric(metric_name, IO::GNUPlotDataSet::PlotType::BoxPlot);
+
+        IO::SvgTerminal terminal;
+        IO::GNUPlotHelper::MultiPlotOptions mpo;
+
+        plot.dump(datasets, terminal, mpo, xtick, legend);
+
+        // Get terminal stream SVG (XML format)
+        IO::GNUPlotHelper& helper = plot.getGNUPlotHelper();
+        std::set<std::string> instance_names = helper.getInstanceNames();
+
+        std::string output;
+        for (const auto& ins_name : instance_names)
+        {
+          helper.getInstanceOutput(ins_name, output);  // Get SVG stream
+          html.writeline(output);
+        }
+      }
+    }
+  }
+
+  html.dump();
+
+  return 0;
+}

--- a/benchmark_suite/src/generate_plots.cpp
+++ b/benchmark_suite/src/generate_plots.cpp
@@ -5,6 +5,7 @@
 #include <moveit_benchmark_suite/yaml.h>
 #include <moveit_benchmark_suite/benchmark.h>
 #include <moveit_benchmark_suite/config/html_config.h>
+#include <moveit_benchmark_suite/aggregation.h>
 
 using namespace moveit_benchmark_suite;
 
@@ -45,7 +46,20 @@ int main(int argc, char** argv)
     return 0;
   }
 
-  // Generate plots to HTML
+  // Aggregate (Optional)
+  AggregateConfig config(ros::this_node::getName());
+
+  const std::vector<std::string>& filter_names = config.getFilterNames();
+  const std::vector<AggregateParams> agg_params = config.getAggregateParams();
+
+  // Create token filters
+  TokenSet agg_filters;
+  for (const auto& filter : filter_names)
+    agg_filters.insert(Token(filter));
+
+  aggregate::dataset(datasets, agg_filters, agg_params);
+
+  // Build HTML
   IO::HTMLPlot html;
   HTMLConfig html_conf(ros::this_node::getName());
 

--- a/benchmark_suite/src/io/gnuplot.cpp
+++ b/benchmark_suite/src/io/gnuplot.cpp
@@ -601,6 +601,11 @@ void GNUPlotDataSet::dump(const std::vector<DataSetPtr>& datasets, const GNUPlot
   }
 };
 
+GNUPlotHelper& GNUPlotDataSet::getGNUPlotHelper()
+{
+  return helper_;
+}
+
 void GNUPlotDataSet::dumpBoxPlot(const std::string& metric, const std::vector<DataSetPtr>& datasets,
                                  const TokenSet& xtick_set, const TokenSet& legend_set)
 

--- a/benchmark_suite/src/io/gnuplot.cpp
+++ b/benchmark_suite/src/io/gnuplot.cpp
@@ -672,15 +672,6 @@ bool GNUPlotDataSet::validOverlap(const TokenSet& xtick_set, const TokenSet& leg
   if (overlap_ctr > xtick_set.size())
     return false;
 
-  for (const auto& t1 : legend_set)
-  {
-    for (const auto& t2 : xtick_set)
-    {
-      if (token::overlap(t1, t2))
-        return false;
-    }
-  }
-
   return true;
 }
 
@@ -851,7 +842,21 @@ bool GNUPlotDataSet::filterDataXtick(const DataPtr& data, const YAML::Node& meta
   node = YAML::Clone(metadata);
   node[DATA_CONFIG_KEY] = data->query->group_name_map;
 
-  for (const auto& token : xtick_set)
+  TokenSet xlabel_set;
+
+  // Default to all data config group value
+  if (xtick_set.empty())
+  {
+    for (const auto& id : data->query->group_name_map)
+      xlabel_set.insert(Token(std::string("config/" + id.first + "/" + id.second)));
+  }
+  else
+  {
+    for (const auto& xlabel : xtick_set)
+      xlabel_set.insert(xlabel);
+  }
+
+  for (const auto& token : xlabel_set)
   {
     YAML::Node res;
     if (!token::compareToNode(token, node, res))

--- a/benchmark_suite/src/io/gnuplot.cpp
+++ b/benchmark_suite/src/io/gnuplot.cpp
@@ -153,9 +153,6 @@ void GNUPlotHelper::getInstanceOutput(const std::string& instance, std::string& 
 
   for (std::string line; std::getline(is, line);)
     output.append(line + "\n");
-
-  if (is.fail())
-    ROS_ERROR("Internal error: istream failed");
 }
 
 void GNUPlotHelper::configureTerminal(const std::string& instance_id, const GNUPlotTerminal& terminal)

--- a/benchmark_suite/src/io/gnuplot.cpp
+++ b/benchmark_suite/src/io/gnuplot.cpp
@@ -40,6 +40,27 @@ std::string QtTerminal::getCmd() const
 }
 
 ///
+/// SvgTerminal
+///
+
+SvgTerminal::SvgTerminal() : GNUPlotTerminal(TERMINAL_SVG_STR)
+{
+}
+
+SvgTerminal::SvgTerminal(const TerminalSize& size) : GNUPlotTerminal(TERMINAL_SVG_STR), size(size)
+{
+}
+
+SvgTerminal::~SvgTerminal()
+{
+}
+
+std::string SvgTerminal::getCmd() const
+{
+  return log::format("set term %1% size %2%,%3%", mode, size.x, size.y);
+}
+
+///
 /// GNUPlotHelper
 ///
 

--- a/benchmark_suite/src/io/gnuplot.cpp
+++ b/benchmark_suite/src/io/gnuplot.cpp
@@ -795,7 +795,7 @@ bool GNUPlotDataSet::filterDataLegend(const DataPtr& data, const YAML::Node& met
         legend_name += token.value;
 
       else
-        legend_name += token.token + ": " + token.value;
+        legend_name += token.group + ": " + token.value;
     else
     {
       // try getting child node keys
@@ -818,7 +818,7 @@ bool GNUPlotDataSet::filterDataLegend(const DataPtr& data, const YAML::Node& met
         legend_name += filter_value;
 
       else
-        legend_name += token.token + ": " + filter_value;
+        legend_name += token.group + ": " + token.value;
     }
 
     legend_name += del;

--- a/benchmark_suite/src/io/gnuplot.cpp
+++ b/benchmark_suite/src/io/gnuplot.cpp
@@ -103,6 +103,17 @@ void GNUPlotHelper::Instance::flush()
     std::cout << std::endl;
 #endif
 }
+
+boost::process::ipstream& GNUPlotHelper::Instance::getOutput()
+{
+  return output_;
+}
+
+boost::process::ipstream& GNUPlotHelper::Instance::getError()
+{
+  return error_;
+}
+
 void GNUPlotHelper::configureTerminal(const std::string& instance_id, const GNUPlotTerminal& terminal)
 {
   auto in = getInstance(instance_id);

--- a/benchmark_suite/src/io/gnuplot.cpp
+++ b/benchmark_suite/src/io/gnuplot.cpp
@@ -73,7 +73,7 @@ GNUPlotHelper::Instance::Instance()
 
   gnuplot_ = bp::child(bp::search_path("gnuplot"),  //"-persist",  //
                        bp::std_err > error_,        //
-                       // bp::std_out > output_,                //
+                       bp::std_out > output_,       //
                        bp::std_in < input_);
 #else
   throw std::runtime_error("GNUPlot helper not supported, Boost 1.64 and above is required!");

--- a/benchmark_suite/src/io/htmlplot.cpp
+++ b/benchmark_suite/src/io/htmlplot.cpp
@@ -1,0 +1,99 @@
+/* Author: Zachary Kingston */
+
+#include <moveit_benchmark_suite/io/htmlplot.h>
+
+#include <moveit_benchmark_suite/io.h>
+#include <moveit_benchmark_suite/log.h>
+
+using namespace moveit_benchmark_suite::IO;
+
+///
+/// HTMLPlot
+///
+
+HTMLPlot::HTMLPlot()
+{
+  std::string filepath = "";
+  std::string filename = "test.html";
+
+  std::string out_file;
+
+  // Create filename if not specified and add extension
+  out_filename = filename;
+  if (out_filename.empty())
+    out_filename = log::format("%1%_%2%", "", IO::getDateStr() + ".html");
+
+  // Set filepath as ROS_HOME
+  out_filepath = filepath;
+  if (out_filepath.empty())
+    out_filepath = IO::getEnvironmentPath("ROS_HOME");
+
+  // Set filepath as default ROS default home path
+  if (out_filepath.empty())
+  {
+    out_filepath = IO::getEnvironmentPath("HOME");
+    out_filepath = out_filepath + "/.ros";
+  }
+  else if (out_filepath[0] != '/')
+  {
+    std::string tmp = out_filepath;
+    out_filepath = IO::getEnvironmentPath("HOME");
+    out_filepath = out_filepath + "/.ros";
+    out_filepath = out_filepath + "/" + tmp;
+  }
+
+  if (!out_filepath.empty() && out_filepath.back() != '/')
+    out_filepath = out_filepath + '/';
+
+  if (!IO::createFile(output_, out_filepath + out_filename))
+  {
+    ROS_ERROR_STREAM(log::format("File creation failed for: '%1%'", out_filepath + out_filename));
+    return;
+  }
+
+  writeline("<!DOCTYPE html>");
+  writeline("<html>");
+  writeline("<body>");
+
+  // CSS: set SVG stacked and horizontally centered
+  writeline("<style>");
+  writeline("svg {");
+  writeline("display: flex;");
+  writeline("justify-content: center;");
+  writeline("align-items: center;");
+  writeline("margin: 0 auto;");
+  writeline("}");
+  writeline("</style>");
+};
+
+void HTMLPlot::write(const std::string& line)
+{
+  output_ << line;
+}
+
+void HTMLPlot::writeline(const std::string& line)
+{
+  write(line);
+  flush();
+}
+
+void HTMLPlot::flush()
+{
+  output_ << std::endl;
+}
+
+void HTMLPlot::dump()
+{
+  if (!output_.is_open())
+  {
+    ROS_WARN("No file open");
+    return;
+  }
+
+  writeline("</body>");
+  writeline("</html>");
+
+  output_.close();
+
+  ROS_INFO_STREAM(log::format("Successfully created HTML file: '%1%'", out_filepath + out_filename));
+}

--- a/benchmark_suite/src/plot_dataset.cpp
+++ b/benchmark_suite/src/plot_dataset.cpp
@@ -68,11 +68,13 @@ int main(int argc, char** argv)
   for (const auto& metric : metrics)
     plot.addMetric(metric.name, metric.type);
 
+  IO::QtTerminal terminal;
+
   IO::GNUPlotHelper::MultiPlotOptions mpo;
   mpo.layout.row = option.n_row;
   mpo.layout.col = option.n_col;
 
-  plot.dump(datasets, mpo, xtick_filters, legend_filters);
+  plot.dump(datasets, terminal, mpo, xtick_filters, legend_filters);
 
   ros::waitForShutdown();
 

--- a/benchmark_suite/src/token.cpp
+++ b/benchmark_suite/src/token.cpp
@@ -95,6 +95,12 @@ Token::Token(const std::string& token, const std::string& del) : token(token), d
     n_key = keys.size();
     key_root = keys[0];
     createTokenNode(0, node);
+
+    // Create group
+    for (int i = 0; i < n_key; ++i)
+      group += keys[i] + del;
+    for (int j = 0; j < del.size(); ++j)
+      group.pop_back();
   }
 }
 


### PR DESCRIPTION
This new node creates an HTML file with embedded SVG pictures to reduce the file size (could be further minimised). For ex. an HTML file containing 60 images has a size of 851 kB.

This will resolve #16.

TODO:
- [x] Configurable via yaml config file
- [x] MGI vs PP
- [x] Scenes&goal constraints
- [x] Planners
- [x] Add documentation