### PR TITLE
Profiler Overhaul

### DIFF
--- a/benchmark_suite/CMakeLists.txt
+++ b/benchmark_suite/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(${PROJECT_NAME}
   src/token.cpp
   src/dataset.cpp
   src/benchmark.cpp
+  src/profiler.cpp
   src/aggregation.cpp
   src/robot.cpp
   src/scene.cpp

--- a/benchmark_suite/include/moveit_benchmark_suite/benchmark.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/benchmark.h
@@ -44,6 +44,7 @@
 #include <moveit_benchmark_suite/io.h>
 #include <moveit_benchmark_suite/log.h>
 #include <moveit_benchmark_suite/io/gnuplot.h>
+#include <moveit_benchmark_suite/profiler.h>
 
 //#include <moveit_benchmark_suite/trajectory.h>
 
@@ -57,21 +58,20 @@ const std::string COLLISION_CHECK = "COLLISION CHECK";
 
 }  // namespace BenchmarkType
 
-struct BenchmarkOptions
-{
-  // Verbose
-  bool verbose_status_query = true;  // Verbose status before each query
-  bool verbose_status_run = false;   // Verbose status before each run
-
-  // Benchmark parameter
-  std::size_t trials = 10;   // Number of trials
-  double query_timeout = 0;  // Timeout for each query
-  double run_timeout = 0;    // Timeout for each run TODO
-};
-
 class Benchmark
 {
 public:
+  struct Options
+  {
+    // Verbose
+    bool verbose_status_query = true;  // Verbose status before each query
+    bool verbose_status_run = false;   // Verbose status before each run
+
+    // Benchmark parameter
+    std::size_t trials = 10;   // Number of trials
+    double query_timeout = 0;  // Timeout for each query
+    double run_timeout = 0;    // Timeout for each run TODO
+  };
   /** \name Building Experiment
       \{ */
 
@@ -83,23 +83,8 @@ public:
    *  \param[in] timeout If true, will re-run each query until the total time taken has exceeded the
    * allotted time.
    */
-  Benchmark(const std::string& name,  //
-            const std::string& type,
-            const Profiler& profiler,  //
-            const QuerySetup& setup_query, BenchmarkOptions = BenchmarkOptions());
-
-  /** \brief Add a query to the experiment for profiling.
-   *  \param[in] planner_name Name to associate with this query. Does not need to be unique.
-   *  \param[in] scene Scene to use for query.
-   *  \param[in] planner Planner to use for query.
-   *  \param[in] request Request to use for query.
-   */
-  void addQuery(const QueryPtr& query);
-
-  /** \brief Get the queries added to this experiment.
-   *  \return The queries added to the experiment.
-   */
-  const std::vector<QueryPtr>& getQueries() const;
+  Benchmark(const std::string& name);
+  Benchmark(const std::string& name, const Options& options);
 
   using PostQueryCallback = std::function<void(DataSetPtr dataset, const Query& query)>;
 
@@ -125,8 +110,96 @@ public:
    *  \param[in] n_threads Number of threads to use for benchmarking.
    *  \return The computed dataset.
    */
-  DataSetPtr run(std::size_t n_threads = 1) const;
 
+  template <typename DerivedQuery, typename DerivedResult>
+  DataSetPtr run(Profiler<DerivedQuery, DerivedResult>& profiler) const
+  {
+    // Setup dataset to return
+    auto dataset = std::make_shared<DataSet>();
+    dataset->name = name_;
+    dataset->uuid = IO::generateUUID();
+    dataset->type = type_;
+    boost::posix_time::microsec_clock clock;
+    dataset->date = IO::getDate(clock);
+    dataset->date_utc = IO::getDateUTC(clock);
+    dataset->start = std::chrono::high_resolution_clock::now();
+    dataset->allowed_time = options_.query_timeout;
+    dataset->trials = options_.trials;
+    dataset->run_till_timeout = options_.run_timeout;
+    dataset->threads = 1.0;
+    dataset->hostname = IO::getHostname();
+
+    dataset->cpuinfo = IO::getHardwareCPU();
+    dataset->gpuinfo = IO::getHardwareGPU();
+    dataset->osinfo = IO::getOSInfo();
+    dataset->moveitinfo = IO::getMoveitInfo();
+    dataset->moveitbenchmarksuiteinfo = IO::getMoveitBenchmarkSuiteInfo();
+
+    dataset->query_setup = query_setup_;
+
+    // Metadata as a YAML node
+    fillMetaData(dataset);
+
+    const auto& queries = profiler.getQueries();
+
+    if (queries.empty())
+    {
+      ROS_ERROR("Cannot run benchmark, no query available");
+      return nullptr;
+    }
+
+    int query_index = 0;
+    for (const auto& query : queries)
+    {
+      // Check if this name is unique, if so, add it to dataset list.
+      const auto& it = std::find(dataset->query_names.begin(), dataset->query_names.end(), query->name);
+      if (it == dataset->query_names.end())
+        dataset->query_names.emplace_back(query->name);
+
+      // profiler_.profileSetup(query);
+
+      if (options_.verbose_status_run && options_.trials > 0)
+
+      {
+        ROS_INFO_STREAM("");
+        ROS_INFO_STREAM(log::format("Running Query [%1%/%2%] with %3% Trials '%4%'",  //
+                                    query_index + 1, queries.size(), options_.trials, query->name));
+      }
+
+      for (std::size_t j = 0; j < options_.trials; ++j)
+      {
+        if (options_.verbose_status_query)
+        {
+          ROS_INFO_STREAM("");
+          ROS_INFO_STREAM(log::format("Running Query [%1%/%2%] Trial [%3%/%4%] '%5%'",  //
+                                      query_index + 1, queries.size(), j + 1, options_.trials, query->name));
+        }
+
+        auto data = std::make_shared<Data>();
+
+        profiler.runQuery(*query, *data);
+
+        // data->query->name = query->name;
+        dataset->addDataPoint(query->name, data);
+
+        for (const auto& post_query_cb : post_query_callbacks_)
+          post_query_cb(dataset, *query);
+      }
+      query_index++;
+
+      for (const auto& post_run_cb : post_run_callbacks_)
+        post_run_cb(dataset, *query);
+    }
+    for (const auto& post_benchmark_cb : post_benchmark_callbacks_)
+      post_benchmark_cb(dataset);
+
+    dataset->finish = std::chrono::high_resolution_clock::now();
+    dataset->time = IO::getSeconds(dataset->start, dataset->finish);
+
+    return dataset;
+  };
+
+  QuerySetup query_setup_;  // TODO move to private
   bool getPlotFlag();
 
 private:
@@ -135,11 +208,7 @@ private:
   const std::string name_;  ///< Name of this experiment.
   const std::string type_;  ///< Name of this experiment.
 
-  // ProfilerType::Options options_;   ///< Options for profiler.
-  const Profiler& profiler_;       ///< Profiler to use for extracting data.
-  std::vector<QueryPtr> queries_;  ///< Queries to test.
-  QuerySetup query_setup_;
-  BenchmarkOptions options_;
+  Options options_;
 
   std::vector<PostQueryCallback> post_query_callbacks_;          ///< Post-run callback with dataset.
   std::vector<PostRunCallback> post_run_callbacks_;              ///< Post-run callback.

--- a/benchmark_suite/include/moveit_benchmark_suite/benchmark.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/benchmark.h
@@ -135,7 +135,7 @@ public:
     dataset->moveitinfo = IO::getMoveitInfo();
     dataset->moveitbenchmarksuiteinfo = IO::getMoveitBenchmarkSuiteInfo();
 
-    dataset->query_setup = query_setup_;
+    dataset->query_setup = profiler.getQuerySetup();
 
     // Metadata as a YAML node
     fillMetaData(dataset);
@@ -155,8 +155,6 @@ public:
       const auto& it = std::find(dataset->query_names.begin(), dataset->query_names.end(), query->name);
       if (it == dataset->query_names.end())
         dataset->query_names.emplace_back(query->name);
-
-      // profiler_.profileSetup(query);
 
       if (options_.verbose_status_run && options_.trials > 0)
 
@@ -207,7 +205,6 @@ public:
     return dataset;
   };
 
-  QuerySetup query_setup_;  // TODO move to private
   bool getPlotFlag();
 
 private:

--- a/benchmark_suite/include/moveit_benchmark_suite/benchmark.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/benchmark.h
@@ -180,14 +180,13 @@ public:
         profiler.preRunQuery(*query, *data);
         data->success = profiler.runQuery(*query, *data);
         profiler.postRunQuery(*query, *data);
-        // data.metrics["thread_id"] = (int)data.thread_id;
-        // data.metrics["process_id"] = (int)data.process_id;
+
+        data->query = query;
         data->hostname = IO::getHostname();
         data->process_id = IO::getProcessID();
         data->thread_id = IO::getThreadID();
         data->metrics["thread_id"] = data->thread_id;
         data->metrics["process_id"] = data->process_id;
-        data->query->name = query->name;
 
         dataset->addDataPoint(query->name, data);
 

--- a/benchmark_suite/include/moveit_benchmark_suite/benchmark.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/benchmark.h
@@ -177,7 +177,11 @@ public:
 
         auto data = std::make_shared<Data>();
 
+        profiler.preRunQuery(*query, *data);
+
         profiler.runQuery(*query, *data);
+
+        profiler.postRunQuery(*query, *data);
 
         // data->query->name = query->name;
         dataset->addDataPoint(query->name, data);

--- a/benchmark_suite/include/moveit_benchmark_suite/benchmark.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/benchmark.h
@@ -178,12 +178,17 @@ public:
         auto data = std::make_shared<Data>();
 
         profiler.preRunQuery(*query, *data);
-
-        profiler.runQuery(*query, *data);
-
+        data->success = profiler.runQuery(*query, *data);
         profiler.postRunQuery(*query, *data);
+        // data.metrics["thread_id"] = (int)data.thread_id;
+        // data.metrics["process_id"] = (int)data.process_id;
+        data->hostname = IO::getHostname();
+        data->process_id = IO::getProcessID();
+        data->thread_id = IO::getThreadID();
+        data->metrics["thread_id"] = data->thread_id;
+        data->metrics["process_id"] = data->process_id;
+        data->query->name = query->name;
 
-        // data->query->name = query->name;
         dataset->addDataPoint(query->name, data);
 
         for (const auto& post_query_cb : post_query_callbacks_)

--- a/benchmark_suite/include/moveit_benchmark_suite/benchmarks/builder/motion_planning.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/benchmarks/builder/motion_planning.h
@@ -50,7 +50,6 @@ public:
   void buildQueries();
 
   const MotionPlanningConfig& getConfig() const;
-  const std::vector<PlanningQueryPtr>& getQueries() const;
   const QuerySetup& getQuerySetup() const;
 
 protected:
@@ -65,8 +64,6 @@ protected:
   QuerySetup query_setup_;
   MotionPlanningConfig mp_config_;
 
-  std::vector<PlanningQueryPtr> queries_;
-
   RobotPtr robot_;
   std::vector<planning_scene::PlanningScenePtr> scenes_;
   std::vector<std::pair<std::string, moveit_msgs::MotionPlanRequest>> requests_;
@@ -77,20 +74,24 @@ class PlanningPipelineBuilder : public MotionPlanningBuilder
 {
 public:
   void buildPlanners() override;
+  const std::vector<PlanningPipelineQueryPtr>& getQueries() const;
 
 protected:
   void appendQuery(const std::string& name, const QueryGroupName& setup, const planning_scene::PlanningScenePtr& scene,
                    const PlannerPtr& planner, const moveit_msgs::MotionPlanRequest& request) override;
+  std::vector<PlanningPipelineQueryPtr> queries_;
 };
 
 class MoveGroupInterfaceBuilder : public MotionPlanningBuilder
 {
 public:
   void buildPlanners() override;
+  const std::vector<MoveGroupInterfaceQueryPtr>& getQueries() const;
 
 protected:
   void appendQuery(const std::string& name, const QueryGroupName& setup, const planning_scene::PlanningScenePtr& scene,
                    const PlannerPtr& planner, const moveit_msgs::MotionPlanRequest& request) override;
+  std::vector<MoveGroupInterfaceQueryPtr> queries_;
 };
 
 }  // namespace moveit_benchmark_suite

--- a/benchmark_suite/include/moveit_benchmark_suite/benchmarks/collision_check_benchmark.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/benchmarks/collision_check_benchmark.h
@@ -46,6 +46,7 @@
 #include <moveit/utils/robot_model_test_utils.h>
 
 #include <moveit_benchmark_suite/dataset.h>
+#include <moveit_benchmark_suite/profiler.h>
 
 namespace moveit_benchmark_suite
 {
@@ -82,35 +83,20 @@ public:
   collision_detection::CollisionResult collision_result;  ///< Planner response.
 };
 
-class CollisionCheckProfiler : public Profiler
+class CollisionCheckProfiler : public Profiler<CollisionCheckQuery, CollisionCheckResult>
 {
 public:
+  CollisionCheckProfiler(const std::string& name);
   /** \brief Bitmask options to select what metrics to compute for each run.
    */
   enum Metrics
   {
-    DISTANCE = 1 << 0,  ///< Number of waypoints in path.
-    CONTACTS = 1 << 1,  ///< Is the path correct (no collisions?).
+    DISTANCE = 1 << 0,  //
+    CONTACTS = 1 << 1,  //
   };
 
-  /** \brief Options for profiling.
-   */
-  struct Options
-  {
-    uint32_t metrics{ uint32_t(~0) };  ///< Bitmask of which metrics to compute after planning.
-  };
-
-  /** \brief Profiling a single plan using a \a planner.
-   *  \param[in] planner Planner to profile.
-   *  \param[in] scene Scene to plan in.
-   *  \param[in] request Planning request to profile.
-   *  \param[in] options The options for profiling.
-   *  \param[out] result The results of profiling.
-   *  \return True if planning succeeded, false on failure.
-   */
-  bool profilePlan(const QueryPtr& query, Data& result) const override;
-  void visualize(const DataSet& dataset) const override;
-
-  Options options_;
+  bool runQuery(const CollisionCheckQuery& query, Data& result) const override;
+  void visualizeQueries(const std::vector<CollisionCheckQueryPtr>& queries) const override;
+  void visualizeQueries() const;
 };
 }  // namespace moveit_benchmark_suite

--- a/benchmark_suite/include/moveit_benchmark_suite/benchmarks/collision_check_benchmark.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/benchmarks/collision_check_benchmark.h
@@ -96,6 +96,8 @@ public:
   };
 
   bool runQuery(const CollisionCheckQuery& query, Data& result) const override;
+  void computeMetrics(uint32_t options, const CollisionCheckQuery& query, const CollisionCheckResult& result,
+                      Data& data) const override;
   void visualizeQueries(const std::vector<CollisionCheckQueryPtr>& queries) const override;
   void visualizeQueries() const;
 };

--- a/benchmark_suite/include/moveit_benchmark_suite/benchmarks/collision_check_benchmark.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/benchmarks/collision_check_benchmark.h
@@ -72,15 +72,14 @@ struct CollisionCheckQuery : public Query
   collision_detection::CollisionRequest request;  ///< Request used for the query.
 };
 
-class CollisionCheckResponse : public Response
+class CollisionCheckResult : public Result
 {
 public:
   /** \name Planning Query and Response
       \{ */
 
   // CollisionCheckQuery query;                      ///< Query evaluated to create this data.
-  collision_detection::CollisionResult response;  ///< Planner response.
-  bool success;                                   ///< Was the plan successful?
+  collision_detection::CollisionResult collision_result;  ///< Planner response.
 };
 
 class CollisionCheckProfiler : public Profiler

--- a/benchmark_suite/include/moveit_benchmark_suite/benchmarks/motion_planning_benchmark.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/benchmarks/motion_planning_benchmark.h
@@ -131,7 +131,7 @@ public:
    *  \param[out] result The results of profiling.
    *  \return True if planning succeeded, false on failure.
    */
-  virtual bool runQuery(const DerivedQuery& query, Data& data) const = 0;
+  virtual bool runQuery(const DerivedQuery& query, Data& data) const override = 0;
 
 protected:
   /** \brief Compute the built-in metrics according to the provided bitmask \a options.
@@ -139,28 +139,27 @@ protected:
    *  \param[in] scene Scene used for planning and metric computation.
    *  \param[out] run Metric results.
    */
-  void computeBuiltinMetrics(uint32_t options, const PlanningResult& result,
-                             const planning_scene::PlanningSceneConstPtr& scene, Data& run) const
+  virtual void computeMetrics(uint32_t options, const DerivedQuery& query, const DerivedResult& result,
+                              Data& data) const override
+
   {
+    data.metrics["time"] = data.time;
+    data.metrics["success"] = data.success;
+
     if (options & Metrics::WAYPOINTS)
-      run.metrics["waypoints"] = run.success ? int(result.trajectory->getNumWaypoints()) : int(0);
+      data.metrics["waypoints"] = data.success ? int(result.trajectory->getNumWaypoints()) : int(0);
 
     if (options & Metrics::LENGTH)
-      run.metrics["length"] = run.success ? result.trajectory->getLength() : 0.0;
+      data.metrics["length"] = data.success ? result.trajectory->getLength() : 0.0;
 
     if (options & Metrics::CORRECT)
-      run.metrics["correct"] = run.success ? result.trajectory->isCollisionFree(scene) : false;
+      data.metrics["correct"] = data.success ? result.trajectory->isCollisionFree(query.scene) : false;
 
     if (options & Metrics::CLEARANCE)
-      run.metrics["clearance"] = run.success ? std::get<0>(result.trajectory->getClearance(scene)) : 0.0;
+      data.metrics["clearance"] = data.success ? std::get<0>(result.trajectory->getClearance(query.scene)) : 0.0;
 
     if (options & Metrics::SMOOTHNESS)
-      run.metrics["smoothness"] = run.success ? result.trajectory->getSmoothness() : 0.0;
-
-    run.metrics["time"] = run.time;
-    run.metrics["success"] = run.success;
-    run.metrics["thread_id"] = (int)run.thread_id;
-    run.metrics["process_id"] = (int)run.process_id;
+      data.metrics["smoothness"] = data.success ? result.trajectory->getSmoothness() : 0.0;
   }
 };
 

--- a/benchmark_suite/include/moveit_benchmark_suite/dataset.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/dataset.h
@@ -57,7 +57,7 @@
 namespace moveit_benchmark_suite
 {
 MOVEIT_CLASS_FORWARD(Query);
-MOVEIT_CLASS_FORWARD(Response);
+MOVEIT_CLASS_FORWARD(Result);
 MOVEIT_CLASS_FORWARD(Data);
 MOVEIT_CLASS_FORWARD(DataSet);
 MOVEIT_CLASS_FORWARD(Profiler);
@@ -130,12 +130,12 @@ struct QuerySetup
   std::map<QueryGroup, std::map<QueryName, QueryResource>> query_setup;
 };
 
-class Response
+class Result
 {
 public:
-  Response() = default;
+  Result() = default;
 
-  virtual ~Response(){};
+  virtual ~Result(){};
   /** \name Planning Query and Response
       \{ */
 
@@ -159,8 +159,8 @@ public:
   bool success;
 
   // Store query and response base class
-  QueryPtr query;        ///< Query evaluated to create this data.
-  ResponsePtr response;  ///< Planner response.
+  QueryPtr query;    ///< Query evaluated to create this data.
+  ResultPtr result;  ///< Planner response.
 
   /** Metrics */
   std::map<std::string, Metric> metrics;  ///< Map of metric name to value.
@@ -172,7 +172,7 @@ public:
   struct QueryResponse
   {
     QueryPtr query;
-    ResponsePtr response;
+    ResultPtr result;
   };
 
   std::string name;  ///< Name of this dataset.

--- a/benchmark_suite/include/moveit_benchmark_suite/dataset.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/dataset.h
@@ -60,7 +60,6 @@ MOVEIT_CLASS_FORWARD(Query);
 MOVEIT_CLASS_FORWARD(Result);
 MOVEIT_CLASS_FORWARD(Data);
 MOVEIT_CLASS_FORWARD(DataSet);
-MOVEIT_CLASS_FORWARD(Profiler);
 
 // Dataset
 static const std::string DATASET_CONFIG_KEY = "config";
@@ -228,37 +227,6 @@ public:
   std::set<std::string> getMetricNames();
 
   std::vector<QueryResponse> getQueryResponse() const;
-};
-
-class Profiler
-{
-public:
-  virtual ~Profiler();
-
-  template <typename DerivedQuery>
-  std::shared_ptr<DerivedQuery> getDerivedClass(const QueryPtr& query) const
-  {
-    auto derived_ptr = std::dynamic_pointer_cast<DerivedQuery>(query);
-    if (!derived_ptr)
-      ROS_ERROR_STREAM("Cannot downcast '" << typeid(DerivedQuery).name() << "' from Query base class'");
-
-    return derived_ptr;
-  };
-
-  template <typename DerivedQuery>
-  std::shared_ptr<DerivedQuery> getDerivedClass(const ResponsePtr& query) const
-  {
-    auto derived_ptr = std::dynamic_pointer_cast<DerivedQuery>(query);
-    if (!derived_ptr)
-      ROS_ERROR_STREAM("Cannot downcast '" << typeid(DerivedQuery).name() << "' from Response base class'");
-
-    return derived_ptr;
-  };
-
-  void profileSetup(const QueryPtr& query) const;
-
-  virtual bool profilePlan(const QueryPtr& query, Data& result) const;
-  virtual void visualize(const DataSet& dataset) const;
 };
 
 }  // namespace moveit_benchmark_suite

--- a/benchmark_suite/include/moveit_benchmark_suite/profiler.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/profiler.h
@@ -95,10 +95,21 @@ public:
   {
   }
 
+  const QuerySetup& getQuerySetup() const
+  {
+    return query_setup_;
+  }
+
+  void setQuerySetup(const QuerySetup& query_setup)
+  {
+    query_setup_ = query_setup;
+  }
+
   Options options;
 
 private:
   const std::string name_;
+  QuerySetup query_setup_;
   std::vector<std::shared_ptr<DerivedQuery>> queries_;
   std::map<QueryName, std::vector<std::shared_ptr<DerivedResult>>> result_map_;
 };

--- a/benchmark_suite/include/moveit_benchmark_suite/profiler.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/profiler.h
@@ -64,6 +64,9 @@ public:
   virtual void preRunQuery(DerivedQuery& query, Data& data){};
   virtual void postRunQuery(const DerivedQuery& query, Data& data){};
 
+  virtual void computeMetrics(uint32_t options, const DerivedQuery& query, const DerivedResult& result,
+                              Data& data) const {};
+
   void addQuery(const DerivedQuery& query)
   {
     addQuery(std::make_shared<DerivedQuery>(query));

--- a/benchmark_suite/include/moveit_benchmark_suite/profiler.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/profiler.h
@@ -61,6 +61,8 @@ public:
   Profiler(const std::string& name) : name_(name){};
   virtual ~Profiler() = default;
   virtual bool runQuery(const DerivedQuery& query, Data& data) const = 0;
+  virtual void preRunQuery(DerivedQuery& query, Data& data){};
+  virtual void postRunQuery(const DerivedQuery& query, Data& data){};
 
   void addQuery(const DerivedQuery& query)
   {

--- a/benchmark_suite/include/moveit_benchmark_suite/profiler.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/profiler.h
@@ -1,0 +1,101 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of Bielefeld University nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: Profiler base class for measurements
+*/
+
+#pragma once
+
+#include <moveit_benchmark_suite/dataset.h>
+
+namespace moveit_benchmark_suite
+{
+template <typename DerivedQuery, typename DerivedResult>
+class Profiler
+{
+  static_assert(std::is_base_of<Query, DerivedQuery>::value,
+                "Profiler template type 'DerivedQuery' must be derived from moveit_benchmark_suite::Query");
+  static_assert(std::is_base_of<Result, DerivedResult>::value,
+                "Profiler template type 'DerivedResult' must be derived from moveit_benchmark_suite::Result");
+
+public:
+  /** \brief Options for profiling.
+   */
+  struct Options
+  {
+    uint32_t metrics{ uint32_t(~0) };  ///< Bitmask of which metrics to compute after planning.
+  };
+
+  Profiler(const std::string& name) : name_(name){};
+  virtual ~Profiler() = default;
+  virtual bool runQuery(const DerivedQuery& query, Data& data) const = 0;
+
+  void addQuery(const DerivedQuery& query)
+  {
+    addQuery(std::make_shared<DerivedQuery>(query));
+  }
+
+  void addQuery(const std::shared_ptr<DerivedQuery>& query)
+  {
+    queries_.emplace_back(query);
+  }
+
+  void addResult(const DerivedQuery& query, const DerivedResult& result)
+  {
+    auto it = result_map_.find(query.name);
+    if (it != result_map_.end())
+      it->second.push_back(std::make_shared<DerivedResult>(result));
+    else
+      result_map_.insert({ query.name, { std::make_shared<DerivedResult>(result) } });
+  }
+
+  const std::vector<std::shared_ptr<DerivedQuery>>& getQueries() const
+  {
+    return queries_;
+  }
+
+  virtual void visualizeQueries(const std::vector<std::shared_ptr<DerivedQuery>>& query) const
+  {
+  }
+
+  Options options;
+
+private:
+  const std::string name_;
+  std::vector<std::shared_ptr<DerivedQuery>> queries_;
+  std::map<QueryName, std::vector<std::shared_ptr<DerivedResult>>> result_map_;
+};
+
+}  // namespace moveit_benchmark_suite

--- a/benchmark_suite/src/benchmark.cpp
+++ b/benchmark_suite/src/benchmark.cpp
@@ -12,10 +12,9 @@
 
 using namespace moveit_benchmark_suite;
 
-Benchmark::Benchmark(const std::string& name,  //
-                     const std::string& type,  //
-                     const Profiler& profiler, const QuerySetup& query_setup, BenchmarkOptions options)
-  : name_(name), type_(type), query_setup_(query_setup), profiler_(profiler), options_(options)
+Benchmark::Benchmark(const std::string& name) : Benchmark(name, Options()){};
+
+Benchmark::Benchmark(const std::string& name, const Options& options) : name_(name), options_(options)
 {
   // Aggregate if config is found
   AggregateConfig agg_config;
@@ -68,25 +67,6 @@ Benchmark::Benchmark(const std::string& name,  //
   }
 };
 
-/** \brief Add a query to the experiment for profiling.
- *  \param[in] planner_name Name to associate with this query. Does not need to be unique.
- *  \param[in] scene Scene to use for query.
- *  \param[in] planner Planner to use for query.
- *  \param[in] request Request to use for query.
- */
-void Benchmark::addQuery(const QueryPtr& query)
-{
-  queries_.emplace_back(query);
-};
-
-/** \brief Get the queries added to this experiment.
- *  \return The queries added to the experiment.
- */
-const std::vector<QueryPtr>& Benchmark::getQueries() const
-{
-  return queries_;
-};
-
 /** \brief Set the post-dataset callback function.
  *  \param[in] callback Callback to use.
  */
@@ -110,91 +90,6 @@ void Benchmark::addPostBenchmarkCallback(const PostBenchmarkCallback& callback)
  *  \param[in] n_threads Number of threads to use for benchmarking.
  *  \return The computed dataset.
  */
-DataSetPtr Benchmark::run(std::size_t n_threads) const
-{
-  // Setup dataset to return
-  auto dataset = std::make_shared<DataSet>();
-  dataset->name = name_;
-  dataset->uuid = IO::generateUUID();
-  dataset->type = type_;
-  boost::posix_time::microsec_clock clock;
-  dataset->date = IO::getDate(clock);
-  dataset->date_utc = IO::getDateUTC(clock);
-  dataset->start = std::chrono::high_resolution_clock::now();
-  dataset->allowed_time = options_.query_timeout;
-  dataset->trials = options_.trials;
-  dataset->run_till_timeout = options_.run_timeout;
-  dataset->threads = n_threads;
-  dataset->hostname = IO::getHostname();
-
-  // dataset->queries = queries_;
-  dataset->cpuinfo = IO::getHardwareCPU();
-  dataset->gpuinfo = IO::getHardwareGPU();
-  dataset->osinfo = IO::getOSInfo();
-  dataset->moveitinfo = IO::getMoveitInfo();
-  dataset->moveitbenchmarksuiteinfo = IO::getMoveitBenchmarkSuiteInfo();
-
-  dataset->query_setup = query_setup_;
-
-  // Metadata as a YAML node
-  fillMetaData(dataset);
-
-  if (queries_.empty())
-  {
-    ROS_ERROR("Cannot run benchmark, no query available");
-    return nullptr;
-  }
-
-  int query_index = 0;
-  for (const auto& query : queries_)
-  {
-    // Check if this name is unique, if so, add it to dataset list.
-    const auto& it = std::find(dataset->query_names.begin(), dataset->query_names.end(), query->name);
-    if (it == dataset->query_names.end())
-      dataset->query_names.emplace_back(query->name);
-
-    profiler_.profileSetup(query);
-
-    if (options_.verbose_status_run && options_.trials > 0)
-
-    {
-      ROS_INFO_STREAM("");
-      ROS_INFO_STREAM(log::format("Running Query [%1%/%2%] with %3% Trials '%4%'",  //
-                                  query_index + 1, queries_.size(), options_.trials, query->name));
-    }
-
-    for (std::size_t j = 0; j < options_.trials; ++j)
-    {
-      if (options_.verbose_status_query)
-      {
-        ROS_INFO_STREAM("");
-        ROS_INFO_STREAM(log::format("Running Query [%1%/%2%] Trial [%3%/%4%] '%5%'",  //
-                                    query_index + 1, queries_.size(), j + 1, options_.trials, query->name));
-      }
-
-      auto data = std::make_shared<Data>();
-
-      profiler_.profilePlan(query, *data);
-
-      // data->query->name = query->name;
-      dataset->addDataPoint(query->name, data);
-
-      for (const auto& post_query_cb : post_query_callbacks_)
-        post_query_cb(dataset, *query);
-    }
-    query_index++;
-
-    for (const auto& post_run_cb : post_run_callbacks_)
-      post_run_cb(dataset, *query);
-  }
-  for (const auto& post_benchmark_cb : post_benchmark_callbacks_)
-    post_benchmark_cb(dataset);
-
-  dataset->finish = std::chrono::high_resolution_clock::now();
-  dataset->time = IO::getSeconds(dataset->start, dataset->finish);
-
-  return dataset;
-};
 
 void Benchmark::fillMetaData(DataSetPtr& dataset) const
 {

--- a/benchmark_suite/src/benchmarks/builder/motion_planning.cpp
+++ b/benchmark_suite/src/benchmarks/builder/motion_planning.cpp
@@ -105,11 +105,6 @@ const MotionPlanningConfig& MotionPlanningBuilder::getConfig() const
   return mp_config_;
 }
 
-const std::vector<PlanningQueryPtr>& MotionPlanningBuilder::getQueries() const
-{
-  return queries_;
-}
-
 const QuerySetup& MotionPlanningBuilder::getQuerySetup() const
 {
   return query_setup_;
@@ -211,6 +206,11 @@ void PlanningPipelineBuilder::appendQuery(const std::string& name, const QueryGr
   queries_.push_back(query);
 }
 
+const std::vector<PlanningPipelineQueryPtr>& PlanningPipelineBuilder::getQueries() const
+{
+  return queries_;
+}
+
 ///
 /// MoveGroupInterfaceBuilder
 ///
@@ -238,4 +238,9 @@ void MoveGroupInterfaceBuilder::appendQuery(const std::string& name, const Query
       std::make_shared<MoveGroupInterfaceQuery>(name, setup, scene, derived_planner, request);
 
   queries_.push_back(query);
+}
+
+const std::vector<MoveGroupInterfaceQueryPtr>& MoveGroupInterfaceBuilder::getQueries() const
+{
+  return queries_;
 }

--- a/benchmark_suite/src/benchmarks/collision_check_benchmark.cpp
+++ b/benchmark_suite/src/benchmarks/collision_check_benchmark.cpp
@@ -63,22 +63,17 @@ CollisionCheckQuery::CollisionCheckQuery(const std::string& name,               
 CollisionCheckProfiler::CollisionCheckProfiler(const std::string& name)
   : Profiler<CollisionCheckQuery, CollisionCheckResult>(name){};
 
-bool CollisionCheckProfiler::runQuery(const CollisionCheckQuery& query,  //
-                                      Data& data) const
+bool CollisionCheckProfiler::runQuery(const CollisionCheckQuery& query, Data& data) const
 {
-  data.query = std::make_shared<CollisionCheckQuery>(query);
-
   CollisionCheckResult result;
-  // Plan
+
+  // Profile time
   data.start = std::chrono::high_resolution_clock::now();
+
   query.scene->checkCollision(query.request, result.collision_result, *query.robot_state);
 
-  // Compute metrics and fill out results
   data.finish = std::chrono::high_resolution_clock::now();
   data.time = IO::getSeconds(data.start, data.finish);
-  data.success = true;
-
-  data.result = std::make_shared<CollisionCheckResult>(result);
 
   // Compute metrics
   computeMetrics(options.metrics, query, result, data);

--- a/benchmark_suite/src/benchmarks/collision_check_benchmark.cpp
+++ b/benchmark_suite/src/benchmarks/collision_check_benchmark.cpp
@@ -57,7 +57,7 @@ CollisionCheckQuery::CollisionCheckQuery(const std::string& name,               
 }
 
 ///
-/// Profiler
+/// CollisionCheckProfiler
 ///
 
 CollisionCheckProfiler::CollisionCheckProfiler(const std::string& name)

--- a/benchmark_suite/src/benchmarks/collision_check_benchmark.cpp
+++ b/benchmark_suite/src/benchmarks/collision_check_benchmark.cpp
@@ -81,12 +81,20 @@ bool CollisionCheckProfiler::runQuery(const CollisionCheckQuery& query,  //
   data.result = std::make_shared<CollisionCheckResult>(result);
 
   // Compute metrics
-  data.metrics["time"] = data.time;
-  if (query.request.contacts)
-    data.metrics["contact_count"] = result.collision_result.contact_count;
-  if (query.request.distance)
-    data.metrics["closest_distance"] = result.collision_result.distance;
+  computeMetrics(options.metrics, query, result, data);
 
+  return true;
+}
+
+void CollisionCheckProfiler::computeMetrics(uint32_t options, const CollisionCheckQuery& query,
+                                            const CollisionCheckResult& result, Data& data) const
+{
+  data.metrics["time"] = data.time;
+
+  if (options & Metrics::CONTACTS && query.request.contacts)
+    data.metrics["contact_count"] = result.collision_result.contact_count;
+  if (options & Metrics::DISTANCE && query.request.distance)
+    data.metrics["closest_distance"] = result.collision_result.distance;
 }
 
 void CollisionCheckProfiler::visualizeQueries(const std::vector<CollisionCheckQueryPtr>& queries) const

--- a/benchmark_suite/src/benchmarks/collision_check_benchmark.cpp
+++ b/benchmark_suite/src/benchmarks/collision_check_benchmark.cpp
@@ -78,9 +78,7 @@ bool CollisionCheckProfiler::runQuery(const CollisionCheckQuery& query,  //
   data.time = IO::getSeconds(data.start, data.finish);
   data.success = true;
 
-  data.hostname = IO::getHostname();
-  data.process_id = IO::getProcessID();
-  data.thread_id = IO::getThreadID();
+  data.result = std::make_shared<CollisionCheckResult>(result);
 
   // Compute metrics
   data.metrics["time"] = data.time;
@@ -89,10 +87,6 @@ bool CollisionCheckProfiler::runQuery(const CollisionCheckQuery& query,  //
   if (query.request.distance)
     data.metrics["closest_distance"] = result.collision_result.distance;
 
-  data.result = std::make_shared<CollisionCheckResult>(result);
-  result.success = data.success;
-
-  return data.success;
 }
 
 void CollisionCheckProfiler::visualizeQueries(const std::vector<CollisionCheckQueryPtr>& queries) const

--- a/benchmark_suite/src/benchmarks/motion_planning_benchmark.cpp
+++ b/benchmark_suite/src/benchmarks/motion_planning_benchmark.cpp
@@ -74,16 +74,13 @@ bool PlanningPipelineProfiler::runQuery(const PlanningPipelineQuery& query, Data
     result.mp_response.trajectory_->getRobotTrajectoryMsg(trajectory_msg);
     result.trajectory->useMessage(result.mp_response.trajectory_->getFirstWayPoint(), trajectory_msg);
   }
-  data.success = result.success;
-  data.hostname = IO::getHostname();
-  data.process_id = IO::getProcessID();
-  data.thread_id = IO::getThreadID();
+
   data.query = std::make_shared<PlanningPipelineQuery>(query);
   data.result = std::make_shared<PlanningResult>(result);
 
   computeMetrics(options.metrics, query, result, data);
 
-  return data.success;
+  return result.success;
 }
 
 ///
@@ -125,10 +122,7 @@ bool MoveGroupInterfaceProfiler::runQuery(const MoveGroupInterfaceQuery& query, 
     result.mp_response.trajectory_->getRobotTrajectoryMsg(trajectory_msg);
     result.trajectory->useMessage(result.mp_response.trajectory_->getFirstWayPoint(), trajectory_msg);
   }
-  data.success = result.success;
-  data.hostname = IO::getHostname();
-  data.process_id = IO::getProcessID();
-  data.thread_id = IO::getThreadID();
+
   data.query = std::make_shared<MoveGroupInterfaceQuery>(query);
   data.result = std::make_shared<PlanningResult>(result);
 

--- a/benchmark_suite/src/benchmarks/motion_planning_benchmark.cpp
+++ b/benchmark_suite/src/benchmarks/motion_planning_benchmark.cpp
@@ -81,7 +81,7 @@ bool PlanningPipelineProfiler::runQuery(const PlanningPipelineQuery& query, Data
   data.query = std::make_shared<PlanningPipelineQuery>(query);
   data.result = std::make_shared<PlanningResult>(result);
 
-  computeBuiltinMetrics(options.metrics, result, query.scene, data);
+  computeMetrics(options.metrics, query, result, data);
 
   return data.success;
 }
@@ -132,7 +132,7 @@ bool MoveGroupInterfaceProfiler::runQuery(const MoveGroupInterfaceQuery& query, 
   data.query = std::make_shared<MoveGroupInterfaceQuery>(query);
   data.result = std::make_shared<PlanningResult>(result);
 
-  computeBuiltinMetrics(options.metrics, result, query.scene, data);
+  computeMetrics(options.metrics, query, result, data);
 
   return result.success;
 }

--- a/benchmark_suite/src/benchmarks/motion_planning_benchmark.cpp
+++ b/benchmark_suite/src/benchmarks/motion_planning_benchmark.cpp
@@ -47,126 +47,92 @@ MoveGroupInterfaceQuery::MoveGroupInterfaceQuery(const std::string& name,       
 }
 
 ///
-/// PlanningProfiler
-///
-
-void PlanningProfiler::computeBuiltinMetrics(uint32_t options, const PlanningQuery& query,
-                                             const PlanningResponse& response,
-                                             const planning_scene::PlanningSceneConstPtr& scene, Data& run) const
-{
-  if (options & Metrics::WAYPOINTS)
-    run.metrics["waypoints"] = run.success ? int(response.trajectory->getNumWaypoints()) : int(0);
-
-  if (options & Metrics::LENGTH)
-    run.metrics["length"] = run.success ? response.trajectory->getLength() : 0.0;
-
-  if (options & Metrics::CORRECT)
-    run.metrics["correct"] = run.success ? response.trajectory->isCollisionFree(scene) : false;
-
-  if (options & Metrics::CLEARANCE)
-    run.metrics["clearance"] = run.success ? std::get<0>(response.trajectory->getClearance(scene)) : 0.0;
-
-  if (options & Metrics::SMOOTHNESS)
-    run.metrics["smoothness"] = run.success ? response.trajectory->getSmoothness() : 0.0;
-
-  run.metrics["time"] = run.time;
-  run.metrics["success"] = run.success;
-  run.metrics["thread_id"] = (int)run.thread_id;
-  run.metrics["process_id"] = (int)run.process_id;
-}
-
-///
 /// PlanningPipelineProfiler
 ///
 
-bool PlanningPipelineProfiler::profilePlan(const QueryPtr& query_base, Data& result) const
+PlanningPipelineProfiler::PlanningPipelineProfiler(const std::string& name)
+  : PlanningProfiler<PlanningPipelineQuery, PlanningResult>(name){};
+
+bool PlanningPipelineProfiler::runQuery(const PlanningPipelineQuery& query, Data& data) const
 {
-  // Get derived query
-  auto query = getDerivedClass<PlanningPipelineQuery>(query_base);
-  if (!query)
-    return false;
+  PlanningResult result;
+  data.start = std::chrono::high_resolution_clock::now();
 
-  // Benchmark function
-  PlanningResponse response;
-  result.start = std::chrono::high_resolution_clock::now();
+  query.planner->plan(query.scene, query.request, result.mp_response);
 
-  query->planner->plan(query->scene, query->request, response.response);
-
-  result.finish = std::chrono::high_resolution_clock::now();
-  result.time = IO::getSeconds(result.start, result.finish);
+  data.finish = std::chrono::high_resolution_clock::now();
+  data.time = IO::getSeconds(data.start, data.finish);
 
   // Compute metrics and fill out results
-  response.success = response.response.error_code_.val == moveit_msgs::MoveItErrorCodes::SUCCESS;
+  result.success = result.mp_response.error_code_.val == moveit_msgs::MoveItErrorCodes::SUCCESS;
 
-  if (response.success)
+  if (result.success)
   {
-    response.trajectory = std::make_shared<Trajectory>(response.response.trajectory_);
+    result.trajectory = std::make_shared<Trajectory>(result.mp_response.trajectory_);
 
     moveit_msgs::RobotTrajectory trajectory_msg;
-    response.response.trajectory_->getRobotTrajectoryMsg(trajectory_msg);
-    response.trajectory->useMessage(response.response.trajectory_->getFirstWayPoint(), trajectory_msg);
+    result.mp_response.trajectory_->getRobotTrajectoryMsg(trajectory_msg);
+    result.trajectory->useMessage(result.mp_response.trajectory_->getFirstWayPoint(), trajectory_msg);
   }
-  result.success = response.success;
-  result.hostname = IO::getHostname();
-  result.process_id = IO::getProcessID();
-  result.thread_id = IO::getThreadID();
-  result.query = std::make_shared<PlanningPipelineQuery>(*query);
-  result.response = std::make_shared<PlanningResponse>(response);
+  data.success = result.success;
+  data.hostname = IO::getHostname();
+  data.process_id = IO::getProcessID();
+  data.thread_id = IO::getThreadID();
+  data.query = std::make_shared<PlanningPipelineQuery>(query);
+  data.result = std::make_shared<PlanningResult>(result);
 
-  computeBuiltinMetrics(options_.metrics, *query, response, query->scene, result);
+  computeBuiltinMetrics(options.metrics, result, query.scene, data);
 
-  return result.success;
+  return data.success;
 }
 
 ///
 /// MoveGroupInterfaceProfiler
 ///
 
-bool MoveGroupInterfaceProfiler::profilePlan(const QueryPtr& query_base, Data& result) const
-{
-  // Get derived query
-  auto query = getDerivedClass<MoveGroupInterfaceQuery>(query_base);
-  if (!query)
-    return false;
+MoveGroupInterfaceProfiler::MoveGroupInterfaceProfiler(const std::string& name)
+  : PlanningProfiler<MoveGroupInterfaceQuery, PlanningResult>(name){};
 
+bool MoveGroupInterfaceProfiler::runQuery(const MoveGroupInterfaceQuery& query, Data& data) const
+{
   // Pre-run callback
-  query->planner->preRun(query->scene, query->request);
+  query.planner->preRun(query.scene, query.request);
 
   // Benchmark
-  PlanningResponse response;
+  PlanningResult result;
   moveit::planning_interface::MoveGroupInterface::Plan plan;
-  result.start = std::chrono::high_resolution_clock::now();
+  data.start = std::chrono::high_resolution_clock::now();
 
-  response.response.error_code_ = query->planner->plan(plan);
+  result.mp_response.error_code_ = query.planner->plan(plan);
 
-  result.finish = std::chrono::high_resolution_clock::now();
-  result.time = IO::getSeconds(result.start, result.finish);
+  data.finish = std::chrono::high_resolution_clock::now();
+  data.time = IO::getSeconds(data.start, data.finish);
 
   // Compute metrics and fill out results
-  response.success = response.response.error_code_.val == moveit_msgs::MoveItErrorCodes::SUCCESS;
+  result.success = result.mp_response.error_code_.val == moveit_msgs::MoveItErrorCodes::SUCCESS;
 
-  if (response.success)
+  if (result.success)
   {
     robot_trajectory::RobotTrajectoryPtr robot_trajectory = std::make_shared<robot_trajectory::RobotTrajectory>(
-        query->planner->getRobot()->getModelConst(), query->request.group_name);
-    robot_trajectory->setRobotTrajectoryMsg(query->scene->getCurrentState(), plan.trajectory_);
+        query.planner->getRobot()->getModelConst(), query.request.group_name);
+    robot_trajectory->setRobotTrajectoryMsg(query.scene->getCurrentState(), plan.trajectory_);
 
-    response.response.trajectory_ = robot_trajectory;
+    result.mp_response.trajectory_ = robot_trajectory;
 
-    response.trajectory = std::make_shared<Trajectory>(robot_trajectory);
+    result.trajectory = std::make_shared<Trajectory>(robot_trajectory);
 
     moveit_msgs::RobotTrajectory trajectory_msg;
-    response.response.trajectory_->getRobotTrajectoryMsg(trajectory_msg);
-    response.trajectory->useMessage(response.response.trajectory_->getFirstWayPoint(), trajectory_msg);
+    result.mp_response.trajectory_->getRobotTrajectoryMsg(trajectory_msg);
+    result.trajectory->useMessage(result.mp_response.trajectory_->getFirstWayPoint(), trajectory_msg);
   }
-  result.success = response.success;
-  result.hostname = IO::getHostname();
-  result.process_id = IO::getProcessID();
-  result.thread_id = IO::getThreadID();
-  result.query = std::make_shared<MoveGroupInterfaceQuery>(*query);
-  result.response = std::make_shared<PlanningResponse>(response);
+  data.success = result.success;
+  data.hostname = IO::getHostname();
+  data.process_id = IO::getProcessID();
+  data.thread_id = IO::getThreadID();
+  data.query = std::make_shared<MoveGroupInterfaceQuery>(query);
+  data.result = std::make_shared<PlanningResult>(result);
 
-  computeBuiltinMetrics(options_.metrics, *query, response, query->scene, result);
+  computeBuiltinMetrics(options.metrics, result, query.scene, data);
 
   return result.success;
 }

--- a/benchmark_suite/src/benchmarks/node/collision_check.cpp
+++ b/benchmark_suite/src/benchmarks/node/collision_check.cpp
@@ -113,7 +113,7 @@ int main(int argc, char** argv)
 
   Benchmark benchmark(benchmark_name,  // Name of benchmark
                       options);        // Options for benchmark
-  benchmark.query_setup_ = query_setup;
+
   // Run benchmark
   auto dataset = benchmark.run(profiler);
 

--- a/benchmark_suite/src/benchmarks/node/collision_check.cpp
+++ b/benchmark_suite/src/benchmarks/node/collision_check.cpp
@@ -99,24 +99,23 @@ int main(int argc, char** argv)
   const auto& query_setup = builder.getQuerySetup();
 
   // Setup profiler
-  CollisionCheckProfiler profiler;
-  profiler.options_.metrics = CollisionCheckProfiler::DISTANCE | CollisionCheckProfiler::CONTACTS;
+  using Metric = CollisionCheckProfiler::Metrics;
+
+  CollisionCheckProfiler profiler(BenchmarkType::COLLISION_CHECK);
+  profiler.setQuerySetup(query_setup);
+  profiler.options.metrics = Metric::DISTANCE | Metric::CONTACTS;
+
+  for (const auto& query : queries)
+    profiler.addQuery(query);
 
   // Setup benchmark
-  BenchmarkOptions bm_options = { .verbose_status_query = false, .verbose_status_run = true, .trials = trials };
+  Benchmark::Options options = { .verbose_status_query = false, .verbose_status_run = true, .trials = trials };
 
-  Benchmark benchmark(benchmark_name,                  // Name of benchmark
-                      BenchmarkType::COLLISION_CHECK,  // Type of benchmark
-                      profiler,                        // Options for internal profiler
-                      query_setup,                     // Number of trials
-                      bm_options);                     // Options for benchmark
-
-  // Add queries
-  for (const auto& query : queries)
-    benchmark.addQuery(query);
-
+  Benchmark benchmark(benchmark_name,  // Name of benchmark
+                      options);        // Options for benchmark
+  benchmark.query_setup_ = query_setup;
   // Run benchmark
-  auto dataset = benchmark.run();
+  auto dataset = benchmark.run(profiler);
 
   if (!dataset)
     return 0;
@@ -134,7 +133,7 @@ int main(int argc, char** argv)
 
   // Visualize dataset results
   if (visualization)
-    profiler.visualize(*dataset);
+    profiler.visualizeQueries();
 
   return 0;
 }

--- a/benchmark_suite/src/benchmarks/node/motion_planning_mgi.cpp
+++ b/benchmark_suite/src/benchmarks/node/motion_planning_mgi.cpp
@@ -105,7 +105,6 @@ int main(int argc, char** argv)
 
   Benchmark benchmark(benchmark_name,  // Name of benchmark
                       options);        // Options for benchmark
-  benchmark.query_setup_ = query_setup;
 
   // Run benchmark
   auto dataset = benchmark.run(profiler);

--- a/benchmark_suite/src/benchmarks/node/motion_planning_mgi.cpp
+++ b/benchmark_suite/src/benchmarks/node/motion_planning_mgi.cpp
@@ -90,25 +90,25 @@ int main(int argc, char** argv)
     benchmark_name = config.getBenchmarkName();
 
   // Setup profiler
-  MoveGroupInterfaceProfiler profiler;
-  profiler.options_.metrics = PlanningProfiler::WAYPOINTS | PlanningProfiler::CORRECT | PlanningProfiler::LENGTH |
-                              PlanningProfiler::SMOOTHNESS | PlanningProfiler::CLEARANCE;
+  using Metric = MoveGroupInterfaceProfiler::Metrics;
+
+  MoveGroupInterfaceProfiler profiler(BenchmarkType::MOTION_PLANNING_MGI);
+  profiler.setQuerySetup(query_setup);
+  profiler.options.metrics =
+      Metric::WAYPOINTS | Metric::CORRECT | Metric::LENGTH | Metric::SMOOTHNESS | Metric::CLEARANCE;
+
+  for (const auto& query : queries)
+    profiler.addQuery(query);
 
   // Setup benchmark
-  BenchmarkOptions bm_options = { .trials = trials, .query_timeout = timeout };
+  Benchmark::Options options = { .trials = trials, .query_timeout = timeout };
 
-  Benchmark benchmark(benchmark_name,                      // Name of benchmark
-                      BenchmarkType::MOTION_PLANNING_MGI,  // Type of benchmark
-                      profiler,                            // Options for internal profiler
-                      query_setup,                         // Number of trials
-                      bm_options);                         // Options for benchmark
-
-  // Add queries
-  for (const auto& query : queries)
-    benchmark.addQuery(query);
+  Benchmark benchmark(benchmark_name,  // Name of benchmark
+                      options);        // Options for benchmark
+  benchmark.query_setup_ = query_setup;
 
   // Run benchmark
-  auto dataset = benchmark.run();
+  auto dataset = benchmark.run(profiler);
 
   if (!dataset)
     return 0;

--- a/benchmark_suite/src/benchmarks/node/motion_planning_pp.cpp
+++ b/benchmark_suite/src/benchmarks/node/motion_planning_pp.cpp
@@ -90,25 +90,25 @@ int main(int argc, char** argv)
     benchmark_name = config.getBenchmarkName();
 
   // Setup profiler
-  PlanningPipelineProfiler profiler;
-  profiler.options_.metrics = PlanningProfiler::WAYPOINTS | PlanningProfiler::CORRECT | PlanningProfiler::LENGTH |
-                              PlanningProfiler::SMOOTHNESS | PlanningProfiler::CLEARANCE;
+  using Metric = PlanningPipelineProfiler::Metrics;
+
+  PlanningPipelineProfiler profiler(BenchmarkType::MOTION_PLANNING_PP);
+  profiler.setQuerySetup(query_setup);
+  profiler.options.metrics =
+      Metric::WAYPOINTS | Metric::CORRECT | Metric::LENGTH | Metric::SMOOTHNESS | Metric::CLEARANCE;
+
+  for (const auto& query : queries)
+    profiler.addQuery(query);
 
   // Setup benchmark
-  BenchmarkOptions bm_options = { .trials = trials, .query_timeout = timeout };
+  Benchmark::Options options = { .trials = trials, .query_timeout = timeout };
 
-  Benchmark benchmark(benchmark_name,                     // Name of benchmark
-                      BenchmarkType::MOTION_PLANNING_PP,  // Type of benchmark
-                      profiler,                           // Options for internal profiler
-                      query_setup,                        // Number of trials
-                      bm_options);                        // Options for benchmark
-
-  // Add queries
-  for (const auto& query : queries)
-    benchmark.addQuery(query);
+  Benchmark benchmark(benchmark_name,  // Name of benchmark
+                      options);        // Options for benchmark
+  benchmark.query_setup_ = query_setup;
 
   // Run benchmark
-  auto dataset = benchmark.run();
+  auto dataset = benchmark.run(profiler);
 
   if (!dataset)
     return 0;

--- a/benchmark_suite/src/benchmarks/node/motion_planning_pp.cpp
+++ b/benchmark_suite/src/benchmarks/node/motion_planning_pp.cpp
@@ -105,7 +105,6 @@ int main(int argc, char** argv)
 
   Benchmark benchmark(benchmark_name,  // Name of benchmark
                       options);        // Options for benchmark
-  benchmark.query_setup_ = query_setup;
 
   // Run benchmark
   auto dataset = benchmark.run(profiler);

--- a/benchmark_suite/src/dataset.cpp
+++ b/benchmark_suite/src/dataset.cpp
@@ -142,21 +142,3 @@ std::vector<DataSet::QueryResponse> DataSet::getQueryResponse() const
 
   return qr;
 }
-
-///
-/// Profiler
-///
-
-Profiler::~Profiler(){};
-
-void Profiler::profileSetup(const QueryPtr& query) const
-{
-}
-
-bool Profiler::profilePlan(const QueryPtr& query, Data& result) const
-{
-  return false;
-}
-void Profiler::visualize(const DataSet& dataset) const
-{
-}

--- a/benchmark_suite/src/dataset.cpp
+++ b/benchmark_suite/src/dataset.cpp
@@ -136,7 +136,7 @@ std::vector<DataSet::QueryResponse> DataSet::getQueryResponse() const
     {
       qr.emplace_back();
       qr.back().query = d.second.front()->query;
-      qr.back().response = d.second.front()->response;
+      qr.back().result = d.second.front()->result;
     }
   }
 

--- a/benchmark_suite/src/profiler.cpp
+++ b/benchmark_suite/src/profiler.cpp
@@ -1,0 +1,3 @@
+#include <moveit_benchmark_suite/profiler.h>
+
+using namespace moveit_benchmark_suite;


### PR DESCRIPTION
Change the way the `Benchmark` and `Profiler` class is interacting with queries. This PR will remove the unnecessary downcasting of queries and simplify the creation of new benchmarks. Also the task of these classes is now more akin to their definition from the Oxford dictionary.

**Profiler**
> an instrument or device for making scientific measurements.

**Benchmark**
> evaluate or check (something) by comparison with a standard.

The Profiler now adds queries instead of the Benchmark. It measures different metrics (time, success, memory). The Benchmark main purpose is to create a dataset by runnning the Profiler queries.

TODO:
- [X] Profiler Overhaul
- [ ] Document the relation between Query, Result, Profiler and Benchmark
- [ ] Document example on how to add a new benchmark
- [x] Add virtual methods for preRuns, postRun in Profiler ?
- [x] Set hostanme, process_id, and thread_id in Benchmark class.
- [x] Unstore query and result from data in Profiler.
- [x] Add query setup in profiler instead of benchmark
- [x] Add callback for computing metrics