### PR TITLE
Add support for vector type of Metric base types

### DIFF
--- a/benchmark_suite/include/moveit_benchmark_suite/dataset.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/dataset.h
@@ -83,6 +83,8 @@ static const std::string DATA_METRIC_KEY = "metrics";
 
 using Metric = boost::variant<bool, double, int, std::size_t, std::string>;
 
+using MetricPtr = std::shared_ptr<Metric>;
+
 /** \brief Convert a planner metric into a string.
  *  \param[in] metric The metric to convert.
  *  \return The metric as a string.

--- a/benchmark_suite/include/moveit_benchmark_suite/dataset.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/dataset.h
@@ -81,7 +81,11 @@ static const std::string DATASET_DATA_KEY = "data";
 static const std::string DATA_CONFIG_KEY = DATASET_CONFIG_KEY;
 static const std::string DATA_METRIC_KEY = "metrics";
 
-using Metric = boost::variant<bool, double, int, std::size_t, std::string>;
+// WARNING
+// Adding/Removing variant types will affect:
+//   - yaml.cpp convert<moveit_benchmark_suite::Metric>::decode
+using Metric = boost::variant<bool, double, int, std::size_t, std::string, std::vector<bool>, std::vector<int>,
+                              std::vector<double>, std::vector<std::size_t>, std::vector<std::string>>;
 
 using MetricPtr = std::shared_ptr<Metric>;
 

--- a/benchmark_suite/include/moveit_benchmark_suite/yaml.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/yaml.h
@@ -155,6 +155,25 @@ void merge(class_overrides& by_class, YAML::Node source);
  */
 class_overrides clone(class_overrides const& by_class);
 
+template <class... Args>
+MetricPtr decodeMetricVariant(const YAML::Node&);
+
+template <class T, class... Args>
+MetricPtr decodeMetricVariantHelper(const YAML::Node& node)
+{
+  try
+  {
+    MetricPtr metric = std::make_shared<Metric>();
+    auto val = node.as<T>();
+    *metric = val;
+    return metric;
+  }
+  catch (YAML::BadConversion& e)
+  {
+    return decodeMetricVariant<Args...>(node);
+  }
+}
+
 // Modified version from https://gist.github.com/kunaltyagi/ebe13098cc22a717f793684659644f4e
 // TODO liscence appropriatly
 
@@ -550,6 +569,13 @@ struct convert<moveit_benchmark_suite::DataSet>
 {
   static Node encode(const moveit_benchmark_suite::DataSet& rhs);
   static bool decode(const Node& node, moveit_benchmark_suite::DataSet& rhs);
+};
+
+template <>
+struct convert<moveit_benchmark_suite::Metric>
+{
+  static Node encode(const moveit_benchmark_suite::Metric& rhs);
+  static bool decode(const Node& node, moveit_benchmark_suite::Metric& rhs);
 };
 
 }  // namespace YAML

--- a/benchmark_suite/src/dataset.cpp
+++ b/benchmark_suite/src/dataset.cpp
@@ -6,7 +6,7 @@
 using namespace moveit_benchmark_suite;
 
 ///
-/// PlannerMetric
+/// MetricVisitors
 ///
 
 namespace
@@ -14,62 +14,76 @@ namespace
 class toMetricStringVisitor : public boost::static_visitor<std::string>
 {
 public:
-  std::string operator()(int value) const
+  std::string operator()(int metric) const
   {
-    return std::to_string(value);
+    return std::to_string(metric);
   }
 
-  std::string operator()(double value) const
+  std::string operator()(double metric) const
   {
-    // double v = boost::get<double>(value);
+    // double v = boost::get<double>(metric);
 
     // [Bad Pun] No NaNs, Infs, or buts about it.
     return boost::lexical_cast<std::string>(  //
-        (std::isfinite(value)) ? value : std::numeric_limits<double>::max());
+        (std::isfinite(metric)) ? metric : std::numeric_limits<double>::max());
   }
 
-  std::string operator()(std::size_t value) const
+  std::string operator()(std::size_t metric) const
   {
-    return std::to_string(value);
+    return std::to_string(metric);
   }
 
-  std::string operator()(bool value) const
+  std::string operator()(bool metric) const
   {
-    return boost::lexical_cast<std::string>(value);
+    return boost::lexical_cast<std::string>(metric);
   }
 
-  std::string operator()(const std::string& value) const
+  std::string operator()(const std::string& metric) const
   {
-    return value;
+    return metric;
+  }
+
+  template <typename T>
+  std::string operator()(const T& metric) const
+  {
+    std::runtime_error("Cannot convert vector to string");
+    return "";
   }
 };
 
 class toMetricDoubleVisitor : public boost::static_visitor<double>
 {
 public:
-  double operator()(int value) const
+  double operator()(int metric) const
   {
-    return static_cast<double>(value);
+    return static_cast<double>(metric);
   }
 
-  double operator()(double value) const
+  double operator()(double metric) const
   {
-    return value;
+    return metric;
   }
 
-  double operator()(std::size_t value) const
+  double operator()(std::size_t metric) const
   {
-    return static_cast<double>(value);
+    return static_cast<double>(metric);
   }
 
-  double operator()(bool value) const
+  double operator()(bool metric) const
   {
-    return static_cast<double>(value);
+    return static_cast<double>(metric);
   }
 
-  double operator()(const std::string& value) const
+  double operator()(const std::string& metric) const
   {
-    return boost::lexical_cast<double>(value);
+    return boost::lexical_cast<double>(metric);
+  }
+
+  template <typename T>
+  double operator()(const T& metric) const
+  {
+    std::runtime_error("Cannot convert vector to double");
+    return std::numeric_limits<double>::quiet_NaN();
   }
 };
 }  // namespace


### PR DESCRIPTION
This will add support for **vector type** of the Metric variant:

```cpp
using Metric = boost::variant<bool, int, double, std::size_t, std::string>;
```