### PR TITLE
Gnuplot redesign

### DIFF
--- a/benchmark_suite/CMakeLists.txt
+++ b/benchmark_suite/CMakeLists.txt
@@ -57,7 +57,7 @@ add_library(${PROJECT_NAME}
   src/benchmark.cpp
   src/profiler.cpp
   src/serialization.cpp
-  src/aggregation.cpp
+  # src/aggregation.cpp
   src/robot.cpp
   src/scene.cpp
   src/log.cpp
@@ -65,7 +65,7 @@ add_library(${PROJECT_NAME}
   src/trajectory.cpp
   src/io/htmlplot.cpp
   src/io/gnuplot.cpp
-  src/config/aggregate_config.cpp
+  # src/config/aggregate_config.cpp
   src/config/collision_check_config.cpp
   src/config/gnuplot_config.cpp
   src/config/html_config.cpp
@@ -90,8 +90,8 @@ target_link_libraries(motion_planning_pp ${PROJECT_NAME} ${catkin_LIBRARIES})
 add_executable(plot_dataset src/plot_dataset.cpp)
 target_link_libraries(plot_dataset ${PROJECT_NAME} ${catkin_LIBRARIES})
 
-add_executable(aggregate src/aggregate.cpp)
-target_link_libraries(aggregate ${PROJECT_NAME} ${catkin_LIBRARIES})
+# add_executable(aggregate src/aggregate.cpp)
+# target_link_libraries(aggregate ${PROJECT_NAME} ${catkin_LIBRARIES})
 
 add_executable(generate_plots src/generate_plots.cpp)
 target_link_libraries(generate_plots ${PROJECT_NAME} ${catkin_LIBRARIES})
@@ -106,7 +106,7 @@ install(TARGETS
   # collision_check
   plot_dataset
   generate_plots
-  aggregate
+  # aggregate
   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/benchmark_suite/config/gnuplot.yaml
+++ b/benchmark_suite/config/gnuplot.yaml
@@ -1,0 +1,18 @@
+gnuplot_config:
+  plots:
+    - #filters:
+      #  - {key: /hw/cpu/model, val: 158, predicate: '='}
+      legends:
+        - metrics/
+      labels:
+        - config/scene/
+        - metrics/
+      metrics:
+        - type: boxplot
+          names:
+            - stage_solution_costs_grasp pose IK
+            - stage_solution_costs_place pose IK
+  options:
+    terminal: QT
+    n_row: 1
+    n_col: 1

--- a/benchmark_suite/config/plots.yaml
+++ b/benchmark_suite/config/plots.yaml
@@ -1,89 +1,106 @@
-html_config:
-  - title: PlanningPipeline vs MoveGroupInterface
-    legend_filters:
-      - type/MOTION PLANNING PP
-      - type/MOTION PLANNING MGI
-    xtick_filters:
-      - config/scene/
-      - config/planner/RRTConnect
-      - config/collision_detector/FCL
-      - config/request/jc-goal
-    metrics:
-      - time: boxplot
+gnuplot_config:
+  plots:
+    - legends:
+        - metrics/
+      labels:
+        - metrics/
+      metrics:
+        - type: boxplot
+          names:
+            - stage_solution_costs_grasp pose IK
+            - stage_solution_costs_place pose IK
+  options:
+    terminal: SVG
+    n_row: 1
+    n_col: 1
 
-  - title: Scenes vs Constraints
-    legend_filters:
-      - type/MOTION PLANNING PP
-      - config/request/
-    xtick_filters:
-      - config/planner/RRTConnect
-      - config/collision_detector/FCL
-    metrics:
-      - time: boxplot
-      - avg_success: bargraph
-      - avg_correct: bargraph
 
-  - title: Planners vs Scenes
-    legend_filters:
-      - type/MOTION PLANNING PP
-      - config/scene/
-    xtick_filters:
-      - config/planner/
-      - config/collision_detector/FCL
-      - config/request/jc-goal
-      - config/pipeline/ompl
-    metrics:
-      - time: boxplot
-      - avg_success: bargraph
-      - avg_correct: bargraph
+# html_config:
+#   - title: PlanningPipeline vs MoveGroupInterface
+#     legend_filters:
+#       - type/MOTION PLANNING PP
+#       - type/MOTION PLANNING MGI
+#     xtick_filters:
+#       - config/scene/
+#       - config/planner/RRTConnect
+#       - config/collision_detector/FCL
+#       - config/request/jc-goal
+#     metrics:
+#       - time: boxplot
 
-  - title: Planners vs Collision Detectors (mesh-scene)
-    legend_filters:
-      - type/MOTION PLANNING PP
-      - config/collision_detector/
-    xtick_filters:
-      - config/scene/bbt-mesh
-      - config/planner/
-      - config/request/jc-goal
-      - config/pipeline/ompl
-    metrics:
-      - time: boxplot
-      - avg_success: bargraph
-      - avg_correct: bargraph
+#   - title: Scenes vs Constraints
+#     legend_filters:
+#       - type/MOTION PLANNING PP
+#       - config/request/
+#     xtick_filters:
+#       - config/planner/RRTConnect
+#       - config/collision_detector/FCL
+#     metrics:
+#       - time: boxplot
+#       - avg_success: bargraph
+#       - avg_correct: bargraph
 
-  - title: Planners vs Collision Detectors (primitive-scene)
-    legend_filters:
-      - type/MOTION PLANNING PP
-      - config/collision_detector/
-    xtick_filters:
-      - config/scene/bbt-primitive
-      - config/planner/
-      - config/request/jc-goal
-      - config/pipeline/ompl
-    metrics:
-      - time: boxplot
-      - avg_success: bargraph
-      - avg_correct: bargraph
+#   - title: Planners vs Scenes
+#     legend_filters:
+#       - type/MOTION PLANNING PP
+#       - config/scene/
+#     xtick_filters:
+#       - config/planner/
+#       - config/collision_detector/FCL
+#       - config/request/jc-goal
+#       - config/pipeline/ompl
+#     metrics:
+#       - time: boxplot
+#       - avg_success: bargraph
+#       - avg_correct: bargraph
 
-  - title: Planners vs Collision Detectors (empty-scene)
-    legend_filters:
-      - type/MOTION PLANNING PP
-      - config/collision_detector/
-    xtick_filters:
-      - config/scene/empty-scene
-      - config/planner/
-      - config/request/jc-goal
-      - config/pipeline/ompl
-    metrics:
-      - time: boxplot
-      - avg_success: bargraph
-      - avg_correct: bargraph
+#   - title: Planners vs Collision Detectors (mesh-scene)
+#     legend_filters:
+#       - type/MOTION PLANNING PP
+#       - config/collision_detector/
+#     xtick_filters:
+#       - config/scene/bbt-mesh
+#       - config/planner/
+#       - config/request/jc-goal
+#       - config/pipeline/ompl
+#     metrics:
+#       - time: boxplot
+#       - avg_success: bargraph
+#       - avg_correct: bargraph
 
-aggregate_config:
-  aggregate:
-    - raw_metric: success
-      new_metric: avg_success
-      type: average
-    - raw_metric: correct
-      new_metric: avg_correct
-      type: average
+#   - title: Planners vs Collision Detectors (primitive-scene)
+#     legend_filters:
+#       - type/MOTION PLANNING PP
+#       - config/collision_detector/
+#     xtick_filters:
+#       - config/scene/bbt-primitive
+#       - config/planner/
+#       - config/request/jc-goal
+#       - config/pipeline/ompl
+#     metrics:
+#       - time: boxplot
+#       - avg_success: bargraph
+#       - avg_correct: bargraph
+
+#   - title: Planners vs Collision Detectors (empty-scene)
+#     legend_filters:
+#       - type/MOTION PLANNING PP
+#       - config/collision_detector/
+#     xtick_filters:
+#       - config/scene/empty-scene
+#       - config/planner/
+#       - config/request/jc-goal
+#       - config/pipeline/ompl
+#     metrics:
+#       - time: boxplot
+#       - avg_success: bargraph
+#       - avg_correct: bargraph
+
+# aggregate_config:
+#   aggregate:
+#     - raw_metric: success
+#       new_metric: avg_success
+#       type: average
+#     - raw_metric: correct
+#       new_metric: avg_correct
+#       type: average

--- a/benchmark_suite/include/moveit_benchmark_suite/benchmark.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/benchmark.h
@@ -95,6 +95,9 @@ public:
     bool verbose_status_trial = true;   // Verbose status before each query trial
     bool verbose_status_query = false;  // Verbose status before each query
 
+    // Config
+    std::string config_file;
+
     // Benchmark parameter
     std::size_t trials = 10;  // Number of trials
     std::string output_file;
@@ -158,7 +161,7 @@ private:
   std::vector<PostBenchmarkCallback> post_benchmark_callbacks_;     ///< Post-run callback.
 
   BenchmarkSuiteDataSetOutputter outputter_;
-  IO::GNUPlotDataSet plot;
+  IO::GNUPlotDataset gnuplot_;
   bool plot_flag = false;
 };
 

--- a/benchmark_suite/include/moveit_benchmark_suite/dataset.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/dataset.h
@@ -218,4 +218,66 @@ public:
   std::vector<QueryResponse> getQueryResponse() const;
 };
 
+enum class Predicate
+{
+  INVALID,
+  EQ,   // equality (=)
+  NEQ,  // non equality (!=)
+  GE,   // greater or equal (>=)
+  GT,   // greater then (>)
+  LE,   // less or equal (<=)
+  LT,   // less then (<)
+};
+
+Predicate stringToPredicate(const std::string& str);
+
+struct Filter
+{
+  Token token;
+  Predicate predicate;
+};
+
+/** \brief Helper class to filter datasets
+ */
+class DatasetFilter
+{
+public:
+  using UUID = std::string;
+  using ContainerID = std::string;
+
+  using DatasetMap = std::multimap<UUID, YAML::Node>;
+  using ContainerMap = std::map<ContainerID, DatasetMap>;
+
+  DatasetFilter();
+  ~DatasetFilter();
+
+  // Dataset from filename | object
+  void loadDataset(const DataSet& dataset);
+  void loadDataset(const YAML::Node& dataset);
+  void loadDataset(const std::string& filename);
+  void loadDatasets(const std::vector<DataSet>& datasets);
+  void loadDatasets(const std::vector<std::string>& filenames);
+
+  /// Except metrics node
+  ///
+  void filter(const std::string& id, const std::vector<Filter>& filters);
+  // TODO add more
+
+  const DatasetMap& getFilteredDataset(const ContainerID& id) const;
+
+private:
+  /** \brief Checks
+   *  \param[in] node Either a dataset node or a data sequence
+   *  \return True if predicate is respected, False otherwise.
+   */
+  bool filterMetadata(const YAML::Node& node, const Token& token, Predicate predicate);
+  /// Queries that contain the metrcis node, for dealing with a variant
+  bool filterMetric(const YAML::Node& node, const Token& token, Predicate predicate);
+
+  DatasetMap dataset_map_;  // Original datasets
+  ContainerMap container_;  // Output of filters
+
+  const DatasetMap empty_dataset_map_;
+};
+
 }  // namespace moveit_benchmark_suite

--- a/benchmark_suite/include/moveit_benchmark_suite/dataset.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/dataset.h
@@ -54,6 +54,8 @@
 #include <ros/console.h>
 
 #include <moveit_benchmark_suite/query.h>
+
+#include <moveit_benchmark_suite/token.h>  // DatasetFilter
 #include <moveit_serialization/yaml-cpp/yaml.h>
 
 namespace moveit_benchmark_suite

--- a/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
@@ -179,27 +179,23 @@ public:
     bool sorted{ true };
 
     ShapeOptions box;
-
-    GNUPlotData datablock;
   };
 
   /** \brief Plot box data.
    *  \param[in] options Plotting options.
    */
-  void boxplot(const BoxPlotOptions& options);
+  void plot(const BoxPlotOptions& options, const GNUPlotData& data);
 
   struct BarGraphOptions : PlottingOptions
   {
     bool percent{ false };  // Defaults to count
     ShapeOptions box;
-
-    GNUPlotData datablock;
   };
 
   /** \brief Plot box data.
    *  \param[in] options Plotting options.
    */
-  void bargraph(const BarGraphOptions& options);
+  void plot(const BarGraphOptions& options, const GNUPlotData& data);
 
   struct MultiPlotOptions : InstanceOptions
   {

--- a/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/io/gnuplot.h
@@ -22,6 +22,8 @@ namespace IO
 static std::string TERMINAL_QT_STR = "qt";
 static std::string TERMINAL_SVG_STR = "svg";
 
+MOVEIT_CLASS_FORWARD(GNUPlotTerminal);
+
 struct TerminalSize
 {
   double x = 640;
@@ -124,6 +126,10 @@ private:
 class GNUPlotHelper
 {
 public:
+  MOVEIT_STRUCT_FORWARD(PlottingOptions);
+  MOVEIT_STRUCT_FORWARD(BoxPlotOptions);
+  MOVEIT_STRUCT_FORWARD(BarGraphOptions);
+
   GNUPlotHelper() = default;
 
   // non-copyable
@@ -184,7 +190,7 @@ public:
   /** \brief Plot box data.
    *  \param[in] options Plotting options.
    */
-  void plot(const BoxPlotOptions& options, const GNUPlotData& data);
+  void plot(const GNUPlotData& data, const BoxPlotOptions& options);
 
   struct BarGraphOptions : PlottingOptions
   {
@@ -195,7 +201,7 @@ public:
   /** \brief Plot box data.
    *  \param[in] options Plotting options.
    */
-  void plot(const BarGraphOptions& options, const GNUPlotData& data);
+  void plot(const GNUPlotData& data, const BarGraphOptions& options);
 
   struct MultiPlotOptions : InstanceOptions
   {
@@ -266,69 +272,75 @@ private:
   std::map<std::string, std::shared_ptr<Instance>> instances_;  ///< Map of open GNUPlot instances
 };
 
-/** \brief Helper class to plot a real metric as a box plot using GNUPlot from benchmarking data.
+/** \brief Plot from datasets using GNUPlot
  */
-
-class GNUPlotDataSet
+class GNUPlotDataset
 {
 public:
   enum PlotType
   {
     BoxPlot,
     BarGraph,
-    TimeSeries,
   };
 
-  std::map<std::string, PlotType> plottype_map = { { "boxplot", PlotType::BoxPlot },
-                                                   { "bargraph", PlotType::BarGraph } };
+  // Represents a subplot
+  struct PlotLayout
+  {
+    PlotType type;
+    GNUPlotHelper::PlottingOptionsPtr options;  // interface
+    std::vector<std::string> metric_names;
+  };
+
+  // Represents multiple subplots
+  struct MultiPlotLayout
+  {
+    std::vector<Filter> filters;
+    std::vector<Token> legends;
+    std::vector<Token> labels;
+
+    std::vector<PlotLayout> plots;
+  };
+
+  // Represent gnuplot global
+  struct GNUPlotLayout
+  {
+    GNUPlotTerminalPtr terminal;
+    GNUPlotHelper::MultiPlotOptions mpo;
+
+    std::vector<MultiPlotLayout> mplots;
+  };
 
   /** \brief Constructor.
    */
-  GNUPlotDataSet();
+  GNUPlotDataset();
 
   /** \brief Destructor.
    */
-  ~GNUPlotDataSet();
+  ~GNUPlotDataset();
 
-  /** \brief Visualize results.
-   *  \param[in] results Results to visualize.
-   */
-  void addMetric(const std::string& metric, const PlotType& plottype);
-  void addMetric(const std::string& metric, const std::string& plottype);
+  bool initialize(const GNUPlotLayout& layout);
+  bool initializeFromYAML(const std::string& file);
 
-  void dump(const DataSetPtr& dataset, const GNUPlotTerminal& terminal, const GNUPlotHelper::MultiPlotOptions& mpo,
-            const TokenSet& xtick_set, const TokenSet& legend_set = {});
-  void dump(const std::vector<DataSetPtr>& datasets, const GNUPlotTerminal& terminal,
-            const GNUPlotHelper::MultiPlotOptions& mpo, const TokenSet& xtick_set, const TokenSet& legend_set = {});
+  // Plot layout from initialization
+  void plot(const DataSet& dataset);
+  void plot(const std::vector<DataSet>& datasets);
+  void plot(const std::vector<std::string>& dataset_files);
 
-  GNUPlotHelper& getGNUPlotHelper();
+  std::set<std::string> getInstanceNames() const;
+  void getInstanceOutput(const std::string& instance_name, std::string& output);
 
 private:
-  void dumpBoxPlot(const std::string& metric, const std::vector<DataSetPtr>& results, const TokenSet& xtick_set,
-                   const TokenSet& legend_set, const GNUPlotHelper::MultiPlotOptions& mpo);
-  void dumpBarGraph(const std::string& metric, const std::vector<DataSetPtr>& results, const TokenSet& xtick_set,
-                    const TokenSet& legend_set, const GNUPlotHelper::MultiPlotOptions& mpo);
+  // Filtered dataset
+  void plot(const GNUPlotLayout& layout);
+  void plot(const MultiPlotLayout& layout, const YAML::Node& dataset);
 
-  bool fillDataSet(const std::string& metric, const std::vector<DataSetPtr>& datasets, const TokenSet& xtick_set,
-                   const TokenSet& legend_set, GNUPlotData& datablock);
+  std::string combineTokenNodeValue(const Token& token, const YAML::Node& node, const std::string& tag);
 
-  bool validOverlap(const TokenSet& xtick_set, const TokenSet& legend_set);
-  bool filterDataSet(const TokenSet& xtick_set, const TokenSet& legend_set, const std::vector<DataSetPtr>& datasets,
-                     std::vector<DataSetPtr>& filtered_datasets);
+  GNUPlotLayout layout_;
+  bool init_ = false;
+  bool single_instance_ = true;
 
-  bool filterDataXtick(const DataPtr& data, const YAML::Node& metadata, const TokenSet& legend_set,
-                       const TokenSet& xtick_set, std::string& xtick_name, const std::string& del,
-                       bool multiple_datasets);
-  bool filterDataLegend(const DataPtr& data, const YAML::Node& metadata, const TokenSet& legend_set,
-                        std::string& legend_name, const std::string& del);
-
-  // bool isLegendFilterValid(const Legend& legend, const Filter& filter, std::vector<LegendKey>& legend_keys,
-  //                          std::vector<FilterKey>& filter_keys);
-
-  // bool isValidData(const DataPtr& data, const std::vector<LegendKey>& legend_keys,
-  //                  const std::vector<FilterKey>& filter_keys, std::string& legend_name, std::string& filter_name);
-
-  std::vector<std::pair<std::string, PlotType>> plot_types_;
+  DatasetFilter dataset_;
   GNUPlotHelper helper_;
 };
 

--- a/benchmark_suite/include/moveit_benchmark_suite/token.h
+++ b/benchmark_suite/include/moveit_benchmark_suite/token.h
@@ -32,8 +32,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-/* Author: Modified version of Zachary Kingston robowflex
-   Desc:
+/* Author: Captain Yoshi
+   Desc: Token for handling namespace
 */
 
 #pragma once
@@ -42,7 +42,7 @@
 #include <vector>
 #include <map>
 
-#include <yaml-cpp/yaml.h>
+#include <moveit_serialization/yaml-cpp/yaml.h>
 
 namespace moveit_benchmark_suite
 {
@@ -50,64 +50,35 @@ std::vector<std::string> splitStr(std::string s, std::string delimiter);
 
 std::string replaceStr(std::string subject, const std::string& search, const std::string& replace);
 
-// Token with empty keys will revert to an empty Token
-struct Token
+///
+class Token
 {
+public:
   Token() = default;
 
-  Token(const std::string& token, const std::string& del = "/");
+  Token(const std::string& ns, const std::string& value = "", const std::string& del = "/");
 
-  void createTokenNode(int i, YAML::Node& n);
   void reset();
 
-  std::string token;
-  std::string group;
-  std::string value;
-  std::string del;
+  const std::string& getValue() const;
+  const std::string& getDelimiter() const;
+  const std::string& getNamespace() const;
 
-  std::vector<std::string> keys;  // Splited token
-  int n_key;
-  std::string key_root;
-  YAML::Node node;
-};  // namespace moveit_benchmark_suite
+  const YAML::Node& getNode() const;
 
-using TokenSet = std::set<Token>;
+  bool hasValue() const;
+  bool isRelative() const;
+  bool isAbsolute() const;
 
-bool operator>(const Token& t1, const Token& t2);
-bool operator>=(const Token& t1, const Token& t2);
-bool operator<(const Token& t1, const Token& t2);
-bool operator<=(const Token& t1, const Token& t2);
+private:
+  void createNode(std::size_t ctr, const std::vector<std::string>& keys, YAML::Node& n);
 
-namespace token
-{
-bool hasValue(const Token& t1);
+  std::string ns_;
+  std::string value_;
+  std::string del_;
 
-// Check tokens overlap ex. overlaps -> "test/alpha" "test/alpha"
-bool overlap(const Token& t1, const Token& t2);
-bool compareToNode(const Token& t, const YAML::Node& node, YAML::Node& res);
-bool compareToNode(const Token& t, const YAML::Node& node);
-
-bool compareToNode(const TokenSet& tokens, const YAML::Node& node);
-
-std::set<std::string> getChildNodeKeys(const YAML::Node& node);
-std::set<std::string> getChildNodeValues(const YAML::Node& node);
-std::map<std::string, std::string> getChildNodeKeyValues(const YAML::Node& node);
-std::string getNodeValue(const YAML::Node& node);
-
-}  // namespace token
-}  // namespace moveit_benchmark_suite
-
-namespace std
-{
-template <>
-struct less<moveit_benchmark_suite::Token>
-
-{
-  bool operator()(const moveit_benchmark_suite::Token lhs, const moveit_benchmark_suite::Token rhs)
-
-  {
-    return lhs.token + lhs.value < rhs.token + rhs.value;
-  }
+  bool ns_rel_ = true;  // namespace is relative or absolute
+  YAML::Node node_;
 };
 
-}  // namespace std
+}  // namespace moveit_benchmark_suite

--- a/benchmark_suite/launch/generate_plots.launch
+++ b/benchmark_suite/launch/generate_plots.launch
@@ -14,7 +14,7 @@
 
   <!-- Launch plot generator node -->
   <node name="generate_plots" pkg="moveit_benchmark_suite" type="generate_plots" respawn="false" clear_params="true" required="true" output="screen" launch-prefix="$(arg launch_prefix)">
-    <rosparam command="load" file="$(arg options_file)"/>
+    <param name="config_file" value="$(find moveit_benchmark_suite)/config/plots.yaml"/>
     <rosparam param="input_files" subst_value="True">$(arg input_files)</rosparam>
   </node>
 

--- a/benchmark_suite/launch/plot_dataset.launch
+++ b/benchmark_suite/launch/plot_dataset.launch
@@ -10,21 +10,8 @@
 
   <node name="plot_dataset" pkg="moveit_benchmark_suite" type="plot_dataset" respawn="false" clear_params="true" required="true" output="screen" launch-prefix="$(arg launch_prefix)">
 
-    <rosparam param="gnuplot_config">
-      xtick_filters:
-        - config/scene/
-      legend_filters:
-        - sw/moveit/git_commit/
-      metrics:
-        - time: boxplot
-        - avg_time: bargraph
-      options:
-          n_row: 2
-          n_col: 1
-          output_script: true
-    </rosparam>
-
-   <rosparam param="input_files" subst_value="True">$(arg input_files)</rosparam>
+    <param name="config_file" value="$(find moveit_benchmark_suite)/config/gnuplot.yaml"/>
+    <rosparam param="input_files" subst_value="True">$(arg input_files)</rosparam>
 
   </node>
 </launch>

--- a/benchmark_suite/src/benchmark.cpp
+++ b/benchmark_suite/src/benchmark.cpp
@@ -1,6 +1,6 @@
 #include <moveit_benchmark_suite/benchmark.h>
 #include <moveit_benchmark_suite/log.h>
-#include <moveit_benchmark_suite/aggregation.h>
+// #include <moveit_benchmark_suite/aggregation.h>
 #include <moveit_benchmark_suite/config/gnuplot_config.h>
 
 #include <queue>
@@ -28,20 +28,20 @@ bool Benchmark::initialize(const std::string& name, const Options& options)
   }
 
   // Aggregate if config is found
-  AggregateConfig agg_config;
-  if (agg_config.isConfigAvailable(""))
-  {
-    agg_config.setNamespace("");
+  // AggregateConfig agg_config;
+  // if (agg_config.isConfigAvailable(""))
+  // {
+  //   agg_config.setNamespace("");
 
-    const std::vector<std::string>& filter_names = agg_config.getFilterNames();
-    const std::vector<AggregateParams> params = agg_config.getAggregateParams();
+  //   const std::vector<std::string>& filter_names = agg_config.getFilterNames();
+  //   const std::vector<AggregateParams> params = agg_config.getAggregateParams();
 
-    TokenSet filters;
-    for (const auto& filter : filter_names)
-      filters.insert(Token(filter));
+  //   TokenSet filters;
+  //   for (const auto& filter : filter_names)
+  //     filters.insert(Token(filter));
 
-    addPostBenchmarkCallback([=](DataSetPtr dataset) { aggregate::dataset(dataset, filters, params); });
-  }
+  //   addPostBenchmarkCallback([=](DataSetPtr dataset) { aggregate::dataset(dataset, filters, params); });
+  // }
 
   // Plot with gnuplot if config is found
   {

--- a/benchmark_suite/src/dataset.cpp
+++ b/benchmark_suite/src/dataset.cpp
@@ -2,6 +2,9 @@
 #include <utility>
 #include <boost/variant.hpp>
 #include <moveit_benchmark_suite/dataset.h>
+#include <moveit_benchmark_suite/io.h>
+#include <moveit_benchmark_suite/serialization.h>
+#include <moveit_serialization/yaml-cpp/node_manipulation.h>
 
 using namespace moveit_benchmark_suite;
 
@@ -155,4 +158,250 @@ std::vector<DataSet::QueryResponse> DataSet::getQueryResponse() const
   }
 
   return qr;
+}
+
+Predicate moveit_benchmark_suite::stringToPredicate(const std::string& str)
+{
+  if (str.compare("=") == 0 || str.compare("==") == 0 || str.compare("eq") == 0 || str.compare("EQ") == 0)
+    return Predicate::EQ;
+  if (str.compare("!=") == 0 || str.compare("neq") == 0 || str.compare("NEQ") == 0)
+    return Predicate::NEQ;
+  if (str.compare(">") == 0 || str.compare("gt") == 0 || str.compare("GT") == 0)
+    return Predicate::GT;
+  if (str.compare(">=") == 0 || str.compare("ge") == 0 || str.compare("GE") == 0)
+    return Predicate::GE;
+  if (str.compare("<") == 0 || str.compare("lt") == 0 || str.compare("LT") == 0)
+    return Predicate::LT;
+  if (str.compare("<=") == 0 || str.compare("le") == 0 || str.compare("LE") == 0)
+    return Predicate::LE;
+
+  return Predicate::INVALID;
+}
+
+///
+/// DatasetFilter
+///
+
+DatasetFilter::DatasetFilter(){};
+
+DatasetFilter::~DatasetFilter(){};
+
+void DatasetFilter::loadDataset(const YAML::Node& node)
+{
+  // Dataset root Node
+  const auto& uuid = node["uuid"].as<std::string>();
+  dataset_map_.insert({ uuid, node });
+
+  // Warn if duplicate keys
+  std::size_t duplicate_keys = dataset_map_.count(uuid);
+  if (duplicate_keys > 1)
+    ROS_WARN("Loaded %s datasets with duplicate uuid '%s'", std::to_string(duplicate_keys).c_str(), uuid.c_str());
+}
+
+void DatasetFilter::loadDataset(const std::string& filename)
+{
+  YAML::Node node;
+
+  if (!IO::loadFileToYAML(filename, node))
+  {
+    ROS_WARN("Failed to load Dataset from file: '%s'", filename.c_str());
+    return;
+  }
+
+  // A file may contain multiple datasets as a sequence
+  for (YAML::const_iterator it = node.begin(); it != node.end(); ++it)
+  {
+    const auto& dataset = *it;
+
+    if (dataset["dataset"] && dataset["dataset"]["uuid"])
+      loadDataset(dataset["dataset"]);
+  }
+}
+
+void DatasetFilter::loadDatasets(const std::vector<std::string>& filenames)
+{
+  for (const auto& filename : filenames)
+    loadDataset(filename);
+}
+
+void DatasetFilter::loadDataset(const DataSet& dataset)
+{
+  YAML::Node node = YAML::toNode(dataset);
+  loadDataset(node);
+}
+
+void DatasetFilter::loadDatasets(const std::vector<DataSet>& datasets)
+{
+  for (const auto& dataset : datasets)
+    loadDataset(dataset);
+}
+
+const DatasetFilter::DatasetMap& DatasetFilter::getFilteredDataset(const ContainerID& id) const
+{
+  auto it = container_.find(id);
+  if (it != container_.end())
+    return it->second;
+  else
+    return empty_dataset_map_;
+}
+
+void DatasetFilter::filter(const std::string& id, const std::vector<Filter>& filters)
+{
+  // Add datasets if no container id found
+  {
+    auto it = container_.find(id);
+    if (it == container_.end())
+      for (const auto& dataset : dataset_map_)
+        container_[id].insert({ dataset.first, YAML::Clone(dataset.second) });
+  }
+
+  // Load dataset from container id
+  auto it = container_.find(id);
+  if (it == container_.end())
+  {
+    ROS_WARN("Empty datasets, did you forget to load them ?");
+    return;
+  }
+
+  auto& dataset_map = it->second;
+
+  // Loop through each dataset
+  for (auto it_dataset = dataset_map.begin(); it_dataset != dataset_map.end(); /* no increment */)
+  {
+    bool filter_success = true;
+    for (const auto& filter : filters)
+    {
+      const auto& token = filter.token;
+      const auto& predicate = filter.predicate;
+
+      // Dataset metadata
+      if (token.isAbsolute())
+      {
+        if (!filterMetadata(it_dataset->second, token, predicate))
+        {
+          filter_success = false;
+          break;
+        }
+      }
+      // Dataset Queries
+      else
+      {
+        std::set<std::size_t> query_indexes;
+        auto queries = it_dataset->second["data"];
+
+        // Loop through each queries
+        for (std::size_t i = 0; i < queries.size(); ++i)
+        {
+          bool rc;
+          const auto& query = queries[i];
+
+          if (token.getNode()["metrics"])
+            rc = filterMetric(query, token, predicate);
+          else
+            rc = filterMetadata(query, token, predicate);
+
+          if (!rc)
+            query_indexes.insert(i);
+        }
+        // Remove filtered queries
+        // use reverse iterator, removing a YAML sequence changes the index order
+        std::set<std::size_t>::const_reverse_iterator revIt = query_indexes.rbegin();
+        while (revIt != query_indexes.rend())
+        {
+          queries.remove(*revIt);
+          ++revIt;
+        }
+
+        // Remove queries node if empty
+        if (queries.size() == 0)
+        {
+          filter_success = false;
+          break;
+        }
+      }
+    }
+
+    if (filter_success)
+      ++it_dataset;
+    else
+      it_dataset = dataset_map.erase(it_dataset);
+  }
+}
+
+bool DatasetFilter::filterMetadata(const YAML::Node& node, const Token& token, Predicate predicate)
+{
+  YAML::Node dataset_value;
+  YAML::Node token_value = YAML::toNode(token.getValue());
+
+  // Compare values between token and dataset
+  if (token.hasValue())
+  {
+    // Token MUST be a subset of the dataset
+    if (!YAML::getSubsetScalar(token.getNode(), node, dataset_value))
+    {
+      ROS_WARN("Filter skipped, namespace '%s' is not a subset of dataset", token.getNamespace().c_str());
+      return true;
+    }
+
+    // Compute predicate
+    YAML::scalar_compare<bool, int, double, std::string> cmp;
+
+    switch (predicate)
+    {
+      case Predicate::EQ:
+        return cmp.equality(token_value, dataset_value);
+      case Predicate::NEQ:
+        return cmp.non_equality(token_value, dataset_value);
+      case Predicate::GT:
+        return cmp.greater_then(token_value, dataset_value);
+      case Predicate::GE:
+        return cmp.greater_equal(token_value, dataset_value);
+      case Predicate::LT:
+        return cmp.lower_then(token_value, dataset_value);
+      case Predicate::LE:
+        return cmp.lower_equal(token_value, dataset_value);
+    }
+  }
+  // Compare keys between token and dataset
+  else
+  {
+    switch (predicate)
+    {
+      // It only makes sense to filter for equality and non-equality
+      case Predicate::EQ:
+        return YAML::isSubset(token.getNode(), node, false);
+      case Predicate::NEQ:
+        return !YAML::isSubset(token.getNode(), node, false);
+      case Predicate::GT:
+      case Predicate::GE:
+      case Predicate::LT:
+      case Predicate::LE:
+        ROS_WARN("Filter skipped, token without value only supports predicates EQ and NEQ");
+        return true;
+    }
+  }
+
+  ROS_WARN("Filter skipped, invalid predicate");
+  return true;
+}
+
+bool DatasetFilter::filterMetric(const YAML::Node& node, const Token& token, Predicate predicate)
+{
+  // Remove
+  if (token.hasValue())
+  {
+    throw std::runtime_error("Filtering the 'metrics' node with value is not implemented yet !");
+    // TODO
+    // const auto& metrics = node["metrics"];
+    // YAML::Node token_value = YAML::toNode(token.getValue());
+
+    // if (metrics.IsScalar()) {}
+    // else if (metrics.IsSequence())
+    // {
+    // }
+
+    // return true;
+  }
+  else
+    return filterMetadata(node, token, predicate);
 }

--- a/benchmark_suite/src/generate_plots.cpp
+++ b/benchmark_suite/src/generate_plots.cpp
@@ -5,7 +5,7 @@
 #include <moveit_serialization/yaml-cpp/yaml.h>
 #include <moveit_benchmark_suite/benchmark.h>
 #include <moveit_benchmark_suite/config/html_config.h>
-#include <moveit_benchmark_suite/aggregation.h>
+// #include <moveit_benchmark_suite/aggregation.h>
 
 using namespace moveit_benchmark_suite;
 

--- a/benchmark_suite/src/generate_plots.cpp
+++ b/benchmark_suite/src/generate_plots.cpp
@@ -9,6 +9,8 @@
 
 using namespace moveit_benchmark_suite;
 
+constexpr char INPUT_PARAMETER[] = "input_files";
+
 int main(int argc, char** argv)
 {
   ros::init(argc, argv, "generate_plots");
@@ -17,91 +19,27 @@ int main(int argc, char** argv)
 
   ros::NodeHandle pnh("~");
 
-  // Parse input file
-  std::vector<std::string> files;
-  pnh.getParam("input_files", files);
+  // Get config
+  std::string config_file;
+  std::vector<std::string> dataset_files;
+  pnh.getParam(INPUT_PARAMETER, dataset_files);
+  pnh.getParam(CONFIG_PARAMETER, config_file);
 
-  // Load datasets from file
-  std::vector<DataSetPtr> datasets;
-  for (const auto& file : files)
-  {
-    std::string abs_file = IO::getAbsDataSetFile(file);
+  // Generate GNUPlot script
+  IO::GNUPlotDataset gnuplot;
 
-    try
-    {
-      auto node = YAML::LoadFile(abs_file);
-      for (YAML::const_iterator it = node.begin(); it != node.end(); ++it)
-        datasets.push_back(std::make_shared<DataSet>(it->as<DataSet>()));
-    }
-    catch (const YAML::BadFile& e)
-    {
-      ROS_FATAL_STREAM("Specified input file '" << abs_file << "' does not exist.");
-      return 1;
-    }
-  }
+  gnuplot.initializeFromYAML(config_file);
+  gnuplot.plot(dataset_files);
 
-  if (datasets.empty())
-  {
-    ROS_WARN_STREAM(log::format("No datasets loaded from files"));
-    return 0;
-  }
-
-  // Aggregate (Optional)
-  AggregateConfig config(ros::this_node::getName());
-
-  const std::vector<std::string>& filter_names = config.getFilterNames();
-  const std::vector<AggregateParams> agg_params = config.getAggregateParams();
-
-  // Create token filters
-  TokenSet agg_filters;
-  for (const auto& filter : filter_names)
-    agg_filters.insert(Token(filter));
-
-  aggregate::dataset(datasets, agg_filters, agg_params);
-
-  // Build HTML
+  // Add GNUPlot instances into HTML
   IO::HTMLPlot html;
-  HTMLConfig html_conf(ros::this_node::getName());
+  auto names = gnuplot.getInstanceNames();
 
-  const auto& configs = html_conf.getConfig();
-  if (configs.empty())
+  for (const auto& name : names)
   {
-    ROS_WARN("No plotting configuration found");
-    return 0;
-  }
-
-  for (const auto& config : configs)
-  {
-    TokenSet legend;
-    TokenSet xtick;
-
-    for (const auto& filter : config.legends)
-      legend.insert(Token(filter));
-    for (const auto& filter : config.xticks)
-      xtick.insert(Token(filter));
-
-    for (const auto& metric : config.metrics)
-    {
-      IO::GNUPlotDataSet plot;
-      plot.addMetric(metric.name, metric.type);
-
-      IO::SvgTerminal terminal;
-      IO::GNUPlotHelper::MultiPlotOptions mpo;
-      mpo.title = config.title;
-
-      plot.dump(datasets, terminal, mpo, xtick, legend);
-
-      // Get terminal stream SVG (XML format)
-      IO::GNUPlotHelper& helper = plot.getGNUPlotHelper();
-      std::set<std::string> instance_names = helper.getInstanceNames();
-
-      std::string output;
-      for (const auto& ins_name : instance_names)
-      {
-        helper.getInstanceOutput(ins_name, output);  // Get SVG stream
-        html.writeline(output);
-      }
-    }
+    std::string output;
+    gnuplot.getInstanceOutput(name, output);
+    html.writeline(output);
   }
 
   html.dump();


### PR DESCRIPTION
Simplify the way Datasets are converted to GNUPlot scripts.

Overview:
 - New filtering class that filters datasets with multiple predicates.
 - Simplify Token class.
 - `GNUPlotDataset` uses a new YAML configuration which gives more options.
 - The `plot_dataset` and `generate_plots` node uses the same configuration.

```yaml
gnuplot_config:
  plots:
    - filters:
        - {key: /hw/cpu/model, val: 158, predicate: '='}
      legends:
        - metrics/
      labels:
        - config/scene/
        - metrics/
      metrics:
        - type: boxplot
          names:
            - stage_solution_costs_grasp pose IK
            - stage_solution_costs_place pose IK
  options:
    terminal: QT

```