### PR TITLE
Implement metadata retrieval 

### DIFF
--- a/core/include/moveit_benchmark_suite/benchmark.h
+++ b/core/include/moveit_benchmark_suite/benchmark.h
@@ -64,6 +64,12 @@ public:
     std::string output_file;
     bool visualize = false;
   };
+
+  using PostTrialCallback = std::function<void(DataSetPtr& dataset)>;
+  using PostQueryCallback = std::function<void(DataSetPtr& dataset)>;
+  using PreBenchmarkCallback = std::function<void(DataSetPtr& dataset)>;
+  using PostBenchmarkCallback = std::function<void(DataSetPtr& dataset)>;
+
   /** \name Building Experiment
       \{ */
 
@@ -81,10 +87,6 @@ public:
   bool initialize(const std::string& name, const Options& options);
   bool initializeFromHandle(const ros::NodeHandle& nh);
 
-  using PostTrialCallback = std::function<void(DataSetPtr& dataset)>;
-  using PostQueryCallback = std::function<void(DataSetPtr& dataset)>;
-  using PostBenchmarkCallback = std::function<void(DataSetPtr& dataset)>;
-
   /** \brief Set the post-dataset callback function.
    *  \param[in] callback Callback to use.
    */
@@ -95,6 +97,7 @@ public:
    */
   void addPostQueryCallback(const PostQueryCallback& callback);
 
+  void addPreBenchmarkCallback(const PreBenchmarkCallback& callback);
   void addPostBenchmarkCallback(const PostBenchmarkCallback& callback);
 
   /** \brief Run benchmarking on this experiment.
@@ -117,6 +120,7 @@ private:
 
   std::vector<PostTrialCallback> post_trial_callbacks_;
   std::vector<PostQueryCallback> post_query_callbacks_;
+  std::vector<PreBenchmarkCallback> pre_benchmark_callbacks_;
   std::vector<PostBenchmarkCallback> post_benchmark_callbacks_;
 };
 }  // namespace moveit_benchmark_suite

--- a/core/include/moveit_benchmark_suite/benchmark.h
+++ b/core/include/moveit_benchmark_suite/benchmark.h
@@ -112,10 +112,7 @@ public:
   const Options& getOptions() const;
 
 private:
-  void fillMetaData(DataSetPtr& dataset) const;
-
   std::string name_;  ///< Name of this experiment.
-
   Options options_;
 
   std::vector<PostTrialCallback> post_trial_callbacks_;

--- a/core/include/moveit_benchmark_suite/dataset.h
+++ b/core/include/moveit_benchmark_suite/dataset.h
@@ -57,62 +57,12 @@
 #include <ros/console.h>
 
 #include <moveit_benchmark_suite/query.h>
+#include <moveit_benchmark_suite/metadata.h>
 
 namespace moveit_benchmark_suite {
+
 MOVEIT_CLASS_FORWARD(Data);
 MOVEIT_CLASS_FORWARD(DataSet);
-
-// Dataset
-static const std::string DATASET_CONFIG_KEY = "config";
-static const std::string DATASET_HW_KEY = "hw";
-static const std::string DATASET_SW_KEY = "sw";
-static const std::string DATASET_OS_KEY = "os";
-static const std::string DATASET_NAME_KEY = "name";
-static const std::string DATASET_UUID_KEY = "uuid";
-static const std::string DATASET_DATE_KEY = "date";
-static const std::string DATASET_DATE_UTC_KEY = "dateutc";
-static const std::string DATASET_TOTAL_TIME_KEY = "totaltime";
-static const std::string DATASET_TYPE_KEY = "type";
-static const std::string DATASET_TIME_LIMIT_KEY = "timelimit";
-static const std::string DATASET_TRIALS_KEY = "trials";
-static const std::string DATASET_HOSTNAME_KEY = "hostname";
-static const std::string DATASET_DATA_KEY = "data";
-
-// Data
-static const std::string DATA_CONFIG_KEY = DATASET_CONFIG_KEY;
-static const std::string DATA_METRIC_KEY = "metrics";
-
-struct CPUInfo
-{
-  std::string model;
-  std::string model_name;
-  std::string family;
-  std::string vendor_id;
-  std::string architecture;
-  std::string sockets;
-  std::string core_per_socket;
-  std::string thread_per_core;
-};
-
-struct GPUInfo
-{
-  std::vector<std::string> model_names;
-};
-
-struct OSInfo
-{
-  std::string kernel_name;
-  std::string kernel_release;
-  std::string distribution;
-  std::string version;
-};
-
-struct RosPkgInfo
-{
-  std::string version;
-  std::string git_branch;
-  std::string git_commit;
-};
 
 // WARNING
 // Adding/Removing variant types will affect:
@@ -175,18 +125,14 @@ public:
   boost::posix_time::ptime date;                          ///< Query start time.
   boost::posix_time::ptime date_utc;                      ///< Query start time.
 
-  // Metadata
-  CPUInfo cpuinfo;
-  GPUInfo gpuinfo;
-  OSInfo osinfo;
-  RosPkgInfo moveitinfo;
-  RosPkgInfo moveitbenchmarksuiteinfo;
+  // HW/SW metadata
+  metadata::OS os;
+  metadata::CPU cpu;
+  std::vector<metadata::GPU> gpus;
+  std::vector<metadata::SW> sw_metadata;
 
   // Setup
   QuerySetup query_setup;
-
-  // Used for filtering diffeent metrics
-  // YAML::Node metadata;
 
   // Benchmark parameters
   double allowed_time;          ///< Allowed time for all queries.

--- a/core/include/moveit_benchmark_suite/io.h
+++ b/core/include/moveit_benchmark_suite/io.h
@@ -46,6 +46,7 @@
 #include <boost/date_time.hpp>  // for date operations
 
 #include <moveit_benchmark_suite/dataset.h>
+#include <moveit_benchmark_suite/metadata.h>
 #include <moveit_benchmark_suite/serialization.h>
 
 namespace moveit_benchmark_suite {
@@ -144,15 +145,6 @@ void deleteFile(const std::string& file);
  */
 const std::pair<bool, std::vector<std::string>> listDirectory(const std::string& directory);
 
-const CPUInfo getHardwareCPU();
-
-const GPUInfo getHardwareGPU();
-
-const OSInfo getOSInfo();
-
-const RosPkgInfo getMoveitInfo();
-const RosPkgInfo getMoveitBenchmarkSuiteInfo();
-
 /** \brief Get the hostname of the system.
  *  \return String of the hostname.
  */
@@ -167,6 +159,33 @@ std::size_t getProcessID();
  *  \return The thread ID.
  */
 std::size_t getThreadID();
+
+/** \brief Get the CPU specification.
+ *  \return The CPU spec.
+ */
+metadata::CPU getCPUMetadata();
+
+/** \brief Get the GPU specification.
+ *  \return The list of GPU spec.
+ */
+std::vector<metadata::GPU> getGPUMetadata();
+
+/** \brief Get the operating system specification.
+ *  \return The OS spec.
+ */
+metadata::OS getOSMetadata();
+
+/** \brief Get ROS package specification.
+ *  \param[in] name Name of the package.
+ *  \return The Software spec.
+ */
+metadata::SW getROSPkgMetadata(const std::string& name);
+
+/** \brief Get Debian package specification.
+ *  \param[in] name Name of the package.
+ *  \return The Software spec.
+ */
+metadata::SW getDebianPkgMetadata(const std::string& name);
 
 /** \brief Get the current time (up to milliseconds)
  *  \return The time.

--- a/core/include/moveit_benchmark_suite/io.h
+++ b/core/include/moveit_benchmark_suite/io.h
@@ -181,6 +181,17 @@ metadata::OS getOSMetadata();
  */
 metadata::SW getROSPkgMetadata(const std::string& name);
 
+/** \brief Get ROS package specification from pluginlib.
+ *  \param[in] plugin_names Names of the plugin class from the xml plugin file
+ *             e.g. <class name="ur_kinematics/UR5KinematicsPlugin" ... >
+ *  \param[in] package_name Names of the ROS package
+ *  \param[in] filter_prefix Package name prefix to filter out
+ *  \return The software specifications.
+ */
+std::vector<metadata::SW> getROSPkgMetadataFromPlugins(const std::set<std::string>& plugin_names,
+                                                       const std::string& package_name = "moveit_core",
+                                                       const std::string& filter_prefix = "moveit");
+
 /** \brief Get Debian package specification.
  *  \param[in] name Name of the package.
  *  \return The Software spec.

--- a/core/include/moveit_benchmark_suite/metadata.h
+++ b/core/include/moveit_benchmark_suite/metadata.h
@@ -1,0 +1,90 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: Collection of hardware and software metadata
+*/
+
+#pragma once
+
+#include <functional>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace moveit_benchmark_suite {
+namespace metadata {
+
+/// Central processing unit
+struct CPU
+{
+  std::string model;
+  std::string model_name;
+  std::string family;
+  std::string vendor_id;
+  std::string architecture;
+  std::string sockets;
+  std::string core_per_socket;
+  std::string thread_per_core;
+};
+
+/// Graphics processing unit
+struct GPU
+{
+  std::string product;
+  std::string vendor;
+  std::string version;
+};
+
+/// Operating system
+struct OS
+{
+  std::string kernel_name;
+  std::string kernel_release;
+  std::string distribution;
+  std::string version;
+};
+
+/// General software
+struct SW
+{
+  std::string name;
+  std::string version;
+  std::string git_branch;
+  std::string git_commit;
+  std::string pkg_manager;  // e.g. DPKG, ROSPackage
+};
+
+}  // namespace metadata
+}  // namespace moveit_benchmark_suite

--- a/core/include/moveit_benchmark_suite/profiler.h
+++ b/core/include/moveit_benchmark_suite/profiler.h
@@ -39,6 +39,7 @@
 #pragma once
 
 #include <moveit_benchmark_suite/dataset.h>
+#include <moveit_benchmark_suite/metadata.h>
 #include <ros/node_handle.h>
 
 namespace moveit_benchmark_suite {
@@ -162,6 +163,10 @@ public:
   virtual void postRunQuery(const DerivedQuery& query, DerivedResult& result, Data& data){};
 
   virtual void buildQueriesFromYAML(const std::string& filename){};
+  virtual std::vector<metadata::SW> getSoftwareMetadata()
+  {
+    return {};
+  };
 
   virtual const std::string& getQueryName(const QueryId query_id) override
   {

--- a/core/include/moveit_benchmark_suite/query.h
+++ b/core/include/moveit_benchmark_suite/query.h
@@ -93,6 +93,19 @@ struct QuerySetup
       it->second.insert(std::pair<QueryName, QueryResource>(name, resource));
   }
 
+  bool hasQueryKey(const std::string& group, const std::string& key) const
+  {
+    auto it = query_setup.find(group);
+    if (it == query_setup.end())
+      return false;
+
+    auto it2 = it->second.find(key);
+    if (it2 == it->second.end())
+      return false;
+
+    return true;
+  }
+
   std::map<QueryGroup, std::map<QueryName, QueryResource>> query_setup;
 };
 

--- a/core/include/moveit_benchmark_suite/serialization.h
+++ b/core/include/moveit_benchmark_suite/serialization.h
@@ -51,31 +51,31 @@ struct convert<moveit_benchmark_suite::QuerySetup>
 };
 
 template <>
-struct convert<moveit_benchmark_suite::CPUInfo>
+struct convert<moveit_benchmark_suite::metadata::CPU>
 {
-  static Node encode(const moveit_benchmark_suite::CPUInfo& rhs);
-  static bool decode(const Node& node, moveit_benchmark_suite::CPUInfo& rhs);
+  static Node encode(const moveit_benchmark_suite::metadata::CPU& rhs);
+  static bool decode(const Node& node, moveit_benchmark_suite::metadata::CPU& rhs);
 };
 
 template <>
-struct convert<moveit_benchmark_suite::GPUInfo>
+struct convert<moveit_benchmark_suite::metadata::GPU>
 {
-  static Node encode(const moveit_benchmark_suite::GPUInfo& rhs);
-  static bool decode(const Node& node, moveit_benchmark_suite::GPUInfo& rhs);
+  static Node encode(const moveit_benchmark_suite::metadata::GPU& rhs);
+  static bool decode(const Node& node, moveit_benchmark_suite::metadata::GPU& rhs);
 };
 
 template <>
-struct convert<moveit_benchmark_suite::OSInfo>
+struct convert<moveit_benchmark_suite::metadata::OS>
 {
-  static Node encode(const moveit_benchmark_suite::OSInfo& rhs);
-  static bool decode(const Node& node, moveit_benchmark_suite::OSInfo& rhs);
+  static Node encode(const moveit_benchmark_suite::metadata::OS& rhs);
+  static bool decode(const Node& node, moveit_benchmark_suite::metadata::OS& rhs);
 };
 
 template <>
-struct convert<moveit_benchmark_suite::RosPkgInfo>
+struct convert<moveit_benchmark_suite::metadata::SW>
 {
-  static Node encode(const moveit_benchmark_suite::RosPkgInfo& rhs);
-  static bool decode(const Node& node, moveit_benchmark_suite::RosPkgInfo& rhs);
+  static Node encode(const moveit_benchmark_suite::metadata::SW& rhs);
+  static bool decode(const Node& node, moveit_benchmark_suite::metadata::SW& rhs);
 };
 
 template <>

--- a/core/src/benchmark.cpp
+++ b/core/src/benchmark.cpp
@@ -103,11 +103,10 @@ DataSetPtr Benchmark::run(Profiler& profiler) const
   dataset->threads = 1.0;
   dataset->hostname = IO::getHostname();
 
-  dataset->cpuinfo = IO::getHardwareCPU();
-  dataset->gpuinfo = IO::getHardwareGPU();
-  dataset->osinfo = IO::getOSInfo();
-  dataset->moveitinfo = IO::getMoveitInfo();
-  dataset->moveitbenchmarksuiteinfo = IO::getMoveitBenchmarkSuiteInfo();
+  dataset->cpu = IO::getCPUMetadata();
+  dataset->gpus = IO::getGPUMetadata();
+  dataset->os = IO::getOSMetadata();
+  // Add software metadata through the pre benchmark callback
 
   dataset->type = profiler.getProfilerName();
   dataset->query_setup = profiler.getQuerySetup();

--- a/core/src/benchmark.cpp
+++ b/core/src/benchmark.cpp
@@ -71,6 +71,12 @@ void Benchmark::addPostQueryCallback(const PostQueryCallback& callback)
 {
   post_query_callbacks_.push_back(callback);
 }
+
+void Benchmark::addPreBenchmarkCallback(const PreBenchmarkCallback& callback)
+{
+  pre_benchmark_callbacks_.push_back(callback);
+}
+
 void Benchmark::addPostBenchmarkCallback(const PostBenchmarkCallback& callback)
 {
   post_benchmark_callbacks_.push_back(callback);
@@ -116,6 +122,9 @@ DataSetPtr Benchmark::run(Profiler& profiler) const
     ROS_ERROR("Cannot run benchmark, no query available");
     return nullptr;
   }
+
+  for (const auto& pre_benchmark_cb : pre_benchmark_callbacks_)
+    pre_benchmark_cb(dataset);
 
   for (std::size_t query_index = 0; query_index < query_size; ++query_index)
   {

--- a/core/src/benchmark.cpp
+++ b/core/src/benchmark.cpp
@@ -112,9 +112,6 @@ DataSetPtr Benchmark::run(Profiler& profiler) const
   dataset->type = profiler.getProfilerName();
   dataset->query_setup = profiler.getQuerySetup();
 
-  // Metadata as a YAML node
-  fillMetaData(dataset);
-
   const auto query_size = profiler.getQuerySize();
 
   if (query_size == 0)
@@ -192,25 +189,3 @@ DataSetPtr Benchmark::run(Profiler& profiler) const
 
   return dataset;
 };
-
-/** \brief Run benchmarking on this experiment.
- *  Note that, for some planners, multiple threads cannot be used without polluting the dataset, due
- * to reuse of underlying datastructures between queries, e.g., the robowflex_ompl planner.
- *  \param[in] n_threads Number of threads to use for benchmarking.
- *  \return The computed dataset.
- */
-
-void Benchmark::fillMetaData(DataSetPtr& dataset) const
-{
-  // dataset->metadata[DATASET_HW_KEY]["cpu"] = dataset->cpuinfo;
-  // dataset->metadata[DATASET_HW_KEY]["gpu"] = dataset->gpuinfo;
-  // dataset->metadata[DATASET_SW_KEY]["moveit"] = dataset->moveitinfo;
-  // dataset->metadata[DATASET_SW_KEY]["moveit_benchmark_suite"] = dataset->moveitbenchmarksuiteinfo;
-  // dataset->metadata[DATASET_OS_KEY] = dataset->osinfo;
-  // dataset->metadata[DATASET_NAME_KEY] = dataset->name;
-  // dataset->metadata[DATASET_TYPE_KEY] = dataset->type;
-  // dataset->metadata[DATASET_UUID_KEY] = dataset->uuid;
-  // dataset->metadata[DATASET_DATE_KEY] = to_simple_string(dataset->date);
-  // dataset->metadata[DATASET_TOTAL_TIME_KEY] = dataset->time;
-  // dataset->metadata[DATASET_CONFIG_KEY] = dataset->query_setup.query_setup;
-}

--- a/core/src/io.cpp
+++ b/core/src/io.cpp
@@ -315,79 +315,81 @@ bool IO::createFile(std::ofstream& out, const std::string& file)
   return true;
 }
 
-const CPUInfo IO::getHardwareCPU()
+metadata::CPU IO::getCPUMetadata()
 {
-  CPUInfo cpuinfo;
+  metadata::CPU cpu;
 
-  cpuinfo.model = IO::runCommand("lscpu | sed -n 's/Model:[ \t]*//p' | tr -d '\n'");
-  cpuinfo.model_name = IO::runCommand("lscpu | sed -n 's/Model name:[ \t]*//p' | tr -d '\n'");
-  cpuinfo.family = IO::runCommand("lscpu | sed -n 's/CPU family:[ \t]*//p' | tr -d '\n'");
-  cpuinfo.vendor_id = IO::runCommand("lscpu | sed -n 's/Vendor ID:[ \t]*//p' | tr -d '\n'");
-  cpuinfo.architecture = IO::runCommand("lscpu | sed -n 's/Architecture:[ \t]*//p' | tr -d '\n'");
-  cpuinfo.sockets = IO::runCommand("lscpu | sed -n 's/Socket(s):[ \t]*//p' | tr -d '\n'");
-  cpuinfo.core_per_socket = IO::runCommand("lscpu | sed -n 's/Core(s) per socket:[ \t]*//p' | tr -d '\n'");
-  cpuinfo.thread_per_core = IO::runCommand("lscpu | sed -n 's/Thread(s) per core:[ \t]*//p' | tr -d '\n'");
+  cpu.model = IO::runCommand("lscpu | sed -n 's/Model:[ \t]*//p' | tr -d '\n'");
+  cpu.model_name = IO::runCommand("lscpu | sed -n 's/Model name:[ \t]*//p' | tr -d '\n'");
+  cpu.family = IO::runCommand("lscpu | sed -n 's/CPU family:[ \t]*//p' | tr -d '\n'");
+  cpu.vendor_id = IO::runCommand("lscpu | sed -n 's/Vendor ID:[ \t]*//p' | tr -d '\n'");
+  cpu.architecture = IO::runCommand("lscpu | sed -n 's/Architecture:[ \t]*//p' | tr -d '\n'");
+  cpu.sockets = IO::runCommand("lscpu | sed -n 's/Socket(s):[ \t]*//p' | tr -d '\n'");
+  cpu.core_per_socket = IO::runCommand("lscpu | sed -n 's/Core(s) per socket:[ \t]*//p' | tr -d '\n'");
+  cpu.thread_per_core = IO::runCommand("lscpu | sed -n 's/Thread(s) per core:[ \t]*//p' | tr -d '\n'");
 
-  return cpuinfo;
+  return cpu;
 }
 
-const GPUInfo IO::getHardwareGPU()
+std::vector<metadata::GPU> IO::getGPUMetadata()
 {
-  GPUInfo gpuinfo;
+  // Supress warnings about not being sudo
+  const std::string N_GPU_STR = IO::runCommand("lshw -C display 2> /dev/null | grep -c '*-display' | tr -d '\n'");
 
-  std::string n_str_lines = IO::runCommand("lspci | grep -c VGA | tr -d '\n'");
-  int n_lines = std::stoi(n_str_lines);
+  const int N_GPU = std::stoi(N_GPU_STR);
+  std::vector<metadata::GPU> gpus;
 
-  for (int i = 0; i < n_lines; ++i)
+  for (int i = 0; i < N_GPU; ++i)
   {
-    std::string model_name = IO::runCommand("lspci | grep VGA | sed -n '" + std::to_string(i + 1) +
-                                            " p' | sed -n 's/.*compatible controller: //p' | tr -d '\n'");
-    gpuinfo.model_names.push_back(model_name);
+    gpus.emplace_back();
+    gpus.back().vendor = IO::runCommand("lshw -C display 2> /dev/null | grep 'vendor:' | sed -n '" +
+                                        std::to_string(i + 1) + " p' | sed -n 's/.*vendor: //p'  | tr -d '\n'");
+    gpus.back().product = IO::runCommand("lshw -C display 2> /dev/null | grep 'product:' | sed -n '" +
+                                         std::to_string(i + 1) + " p' | sed -n 's/.*product: //p'  | tr -d '\n'");
+    gpus.back().version = IO::runCommand("lshw -C display 2> /dev/null | grep 'version:' | sed -n '" +
+                                         std::to_string(i + 1) + " p' | sed -n 's/.*version: //p'  | tr -d '\n'");
   }
-  return gpuinfo;
+
+  return gpus;
 }
 
-const OSInfo IO::getOSInfo()
+metadata::OS IO::getOSMetadata()
 {
-  OSInfo osinfo;
-
-  osinfo.kernel_name = IO::runCommand("uname --kernel-name | tr -d '\n'");
-  osinfo.kernel_release = IO::runCommand("uname --kernel-release | tr -d '\n'");
-  osinfo.distribution = IO::runCommand("cat /etc/*release | sed -n 's/DISTRIB_ID=//p' | tr -d '\n'");
-  osinfo.version =
+  metadata::OS os;
+  os.kernel_name = IO::runCommand("uname --kernel-name | tr -d '\n'");
+  os.kernel_release = IO::runCommand("uname --kernel-release | tr -d '\n'");
+  os.distribution = IO::runCommand("cat /etc/*release | sed -n 's/DISTRIB_ID=//p' | tr -d '\n'");
+  os.version =
       IO::runCommand("cat /etc/*release | sed -n 's/VERSION=//p' | tr -d '\n' | sed -e 's/^\"//' -e 's/\"$//'");
 
-  return osinfo;
+  return os;
 }
 
-const RosPkgInfo IO::getMoveitInfo()
+metadata::SW IO::getROSPkgMetadata(const std::string& name)
 {
-  std::string path = resolvePackage("package://moveit_core");
+  metadata::SW sw;
 
-  RosPkgInfo info;
+  std::string pathname = resolvePackage("package://" + name);
 
-  info.version = MOVEIT_VERSION_STR;
-  // info.git_branch = MOVEIT_GIT_BRANCH;
-  // info.git_commit = MOVEIT_GIT_COMMIT_HASH;
-  info.git_branch = IO::runCommand(log::format("(cd %1% && git rev-parse --abbrev-ref HEAD | tr -d '\n')", path));
-  info.git_commit = IO::runCommand(log::format("(cd %1% && git rev-parse HEAD | tr -d '\n')", path));
+  sw.name = name;
+  sw.version = IO::runCommand(log::format("(rosversion %1% | tr -d '\n')", name));
+  sw.git_branch = IO::runCommand(log::format("(cd %1% && git rev-parse --abbrev-ref HEAD | tr -d '\n')", pathname));
+  sw.git_commit = IO::runCommand(log::format("(cd %1% && git rev-parse HEAD | tr -d '\n')", pathname));
+  sw.pkg_manager = "ROS Package";
 
-  return info;
+  return sw;
 }
 
-const RosPkgInfo IO::getMoveitBenchmarkSuiteInfo()
+metadata::SW IO::getDebianPkgMetadata(const std::string& name)
 {
-  std::string path = resolvePackage("package://moveit_benchmark_suite_core");
+  metadata::SW sw;
 
-  RosPkgInfo info;
+  sw.name = name;
+  sw.version =
+      IO::runCommand(log::format("dpkg -s %1% | grep '^Version:' | sed -n 's/.*Version: //p' | tr -d '\n'", name));
+  sw.pkg_manager = "DPKG";
 
-  info.version = "0.0.7";
-  // info.git_branch = MOVEIT_GIT_BRANCH;
-  // info.git_commit = MOVEIT_GIT_COMMIT_HASH;
-  info.git_branch = IO::runCommand(log::format("(cd %1% && git rev-parse --abbrev-ref HEAD | tr -d '\n')", path));
-  info.git_commit = IO::runCommand(log::format("(cd %1% && git rev-parse HEAD | tr -d '\n')", path));
-
-  return info;
+  return sw;
 }
 
 const std::string IO::getHostname()

--- a/core/src/serialization.cpp
+++ b/core/src/serialization.cpp
@@ -383,19 +383,6 @@ bool convert<moveit_benchmark_suite::DataSet>::decode(const Node& node, moveit_b
     }
   }
 
-  // Fill metadata
-  // rhs.metadata[DATASET_HW_KEY]["cpu"] = rhs.cpuinfo;
-  // rhs.metadata[DATASET_HW_KEY]["gpu"] = rhs.gpuinfo;
-  // rhs.metadata[DATASET_SW_KEY]["moveit"] = rhs.moveitinfo;
-  // rhs.metadata[DATASET_SW_KEY]["moveit_benchmark_suite"] = rhs.moveitbenchmarksuiteinfo;
-  // rhs.metadata[DATASET_OS_KEY] = rhs.osinfo;
-  // rhs.metadata[DATASET_NAME_KEY] = rhs.name;
-  // rhs.metadata[DATASET_TYPE_KEY] = rhs.type;
-  // rhs.metadata[DATASET_UUID_KEY] = rhs.uuid;
-  // rhs.metadata[DATASET_DATE_KEY] = to_simple_string(rhs.date);
-  // rhs.metadata[DATASET_TOTAL_TIME_KEY] = rhs.time;
-  // rhs.metadata[DATASET_CONFIG_KEY] = rhs.query_setup.query_setup;
-
   return true;
 }
 Node convert<moveit_benchmark_suite::Metric>::encode(const moveit_benchmark_suite::Metric& rhs)

--- a/core/src/serialization.cpp
+++ b/core/src/serialization.cpp
@@ -94,7 +94,7 @@ bool convert<moveit_benchmark_suite::QuerySetup>::decode(const Node& node, movei
   return true;
 }
 
-Node convert<moveit_benchmark_suite::CPUInfo>::encode(const moveit_benchmark_suite::CPUInfo& rhs)
+Node convert<moveit_benchmark_suite::metadata::CPU>::encode(const moveit_benchmark_suite::metadata::CPU& rhs)
 {
   Node node;
 
@@ -110,7 +110,7 @@ Node convert<moveit_benchmark_suite::CPUInfo>::encode(const moveit_benchmark_sui
   return node;
 }
 
-bool convert<moveit_benchmark_suite::CPUInfo>::decode(const Node& node, moveit_benchmark_suite::CPUInfo& rhs)
+bool convert<moveit_benchmark_suite::metadata::CPU>::decode(const Node& node, moveit_benchmark_suite::metadata::CPU& rhs)
 {
   rhs.model = node["model"].as<std::string>();
   rhs.model_name = node["model_name"].as<std::string>();
@@ -124,27 +124,27 @@ bool convert<moveit_benchmark_suite::CPUInfo>::decode(const Node& node, moveit_b
   return true;
 }
 
-Node convert<moveit_benchmark_suite::GPUInfo>::encode(const moveit_benchmark_suite::GPUInfo& rhs)
+Node convert<moveit_benchmark_suite::metadata::GPU>::encode(const moveit_benchmark_suite::metadata::GPU& rhs)
 {
   Node node;
 
-  for (const auto& model_name : rhs.model_names)
-    node["model_names"].push_back(model_name);
+  node["product"] = rhs.product;
+  node["vendor"] = rhs.vendor;
+  node["version"] = rhs.version;
 
   return node;
 }
 
-bool convert<moveit_benchmark_suite::GPUInfo>::decode(const Node& node, moveit_benchmark_suite::GPUInfo& rhs)
+bool convert<moveit_benchmark_suite::metadata::GPU>::decode(const Node& node, moveit_benchmark_suite::metadata::GPU& rhs)
 {
-  int n_model = node["model_names"].size();
-
-  for (int i = 0; i < n_model; ++i)
-    rhs.model_names.push_back(node["model_names"][i].as<std::string>());
+  rhs.product = node["product"].as<std::string>("");
+  rhs.vendor = node["vendor"].as<std::string>("");
+  rhs.version = node["version"].as<std::string>("");
 
   return true;
 }
 
-Node convert<moveit_benchmark_suite::OSInfo>::encode(const moveit_benchmark_suite::OSInfo& rhs)
+Node convert<moveit_benchmark_suite::metadata::OS>::encode(const moveit_benchmark_suite::metadata::OS& rhs)
 {
   Node node;
 
@@ -156,32 +156,43 @@ Node convert<moveit_benchmark_suite::OSInfo>::encode(const moveit_benchmark_suit
   return node;
 }
 
-bool convert<moveit_benchmark_suite::OSInfo>::decode(const Node& node, moveit_benchmark_suite::OSInfo& rhs)
+bool convert<moveit_benchmark_suite::metadata::OS>::decode(const Node& node, moveit_benchmark_suite::metadata::OS& rhs)
 {
-  rhs.kernel_name = node["kernel_name"].as<std::string>();
-  rhs.kernel_release = node["kernel_release"].as<std::string>();
-  rhs.distribution = node["distribution"].as<std::string>();
-  rhs.version = node["version"].as<std::string>();
+  rhs.kernel_name = node["kernel_name"].as<std::string>("");
+  rhs.kernel_release = node["kernel_release"].as<std::string>("");
+  rhs.distribution = node["distribution"].as<std::string>("");
+  rhs.version = node["version"].as<std::string>("");
 
   return true;
 }
 
-Node convert<moveit_benchmark_suite::RosPkgInfo>::encode(const moveit_benchmark_suite::RosPkgInfo& rhs)
+Node convert<moveit_benchmark_suite::metadata::SW>::encode(const moveit_benchmark_suite::metadata::SW& rhs)
 {
   Node node;
 
+  node["name"] = rhs.name;
   node["version"] = rhs.version;
-  node["git_branch"] = rhs.git_branch;
-  node["git_commit"] = rhs.git_commit;
+
+  if (!rhs.pkg_manager.empty())
+    node["pkg_manager"] = rhs.pkg_manager;
+
+  if (!rhs.git_branch.empty())
+  {
+    node["git_branch"] = rhs.git_branch;
+    node["git_commit"] = rhs.git_commit;
+  }
 
   return node;
 }
 
-bool convert<moveit_benchmark_suite::RosPkgInfo>::decode(const Node& node, moveit_benchmark_suite::RosPkgInfo& rhs)
+bool convert<moveit_benchmark_suite::metadata::SW>::decode(const Node& node, moveit_benchmark_suite::metadata::SW& rhs)
 {
+  rhs.name = node["name"].as<std::string>();
   rhs.version = node["version"].as<std::string>();
-  rhs.git_branch = node["git_branch"].as<std::string>();
-  rhs.git_commit = node["git_commit"].as<std::string>();
+  rhs.pkg_manager = node["pkg_manager"].as<std::string>("");
+
+  rhs.git_branch = node["git_branch"].as<std::string>("");
+  rhs.git_commit = node["git_commit"].as<std::string>("");
 
   return true;
 }
@@ -218,28 +229,27 @@ Node convert<moveit_benchmark_suite::DataSet>::encode(const moveit_benchmark_sui
   Node node;
 
   // dataset
-  node[DATASET_NAME_KEY] = rhs.name;
-  node[DATASET_TYPE_KEY] = rhs.type;
-  node[DATASET_UUID_KEY] = rhs.uuid;
-  node[DATASET_DATE_KEY] = to_simple_string(rhs.date);
-  node[DATASET_DATE_UTC_KEY] = to_simple_string(rhs.date_utc);
-  node[DATASET_TOTAL_TIME_KEY] = rhs.time;
-  node[DATASET_TIME_LIMIT_KEY] = rhs.allowed_time;
-  node[DATASET_TRIALS_KEY] = rhs.trials;
-  node[DATASET_HOSTNAME_KEY] = rhs.hostname;
+  node["name"] = rhs.name;
+  node["type"] = rhs.type;
+  node["uuid"] = rhs.uuid;
+  node["date"] = to_simple_string(rhs.date);
+  node["date_utc"] = to_simple_string(rhs.date_utc);
+  node["total_time"] = rhs.time;
+  node["timelimit"] = rhs.allowed_time;
+  node["trials"] = rhs.trials;
+  node["hostname"] = rhs.hostname;
 
   // hw
-  node[DATASET_HW_KEY]["cpu"] = rhs.cpuinfo;
-  node[DATASET_HW_KEY]["gpu"] = rhs.gpuinfo;
+  node["cpu"] = rhs.cpu;
+  node["gpu"] = rhs.gpus;
 
   // sw
-  node[DATASET_SW_KEY]["moveit"] = rhs.moveitinfo;
-  node[DATASET_SW_KEY]["moveit_benchmark_suite"] = rhs.moveitbenchmarksuiteinfo;
+  node["sw"] = rhs.sw_metadata;
 
   // os
-  node[DATASET_OS_KEY] = rhs.osinfo;
+  node["os"] = rhs.os;
 
-  node[DATASET_CONFIG_KEY] = rhs.query_setup.query_setup;
+  node["config"] = rhs.query_setup.query_setup;
 
   for (const auto& data_map : rhs.data)
   {
@@ -247,17 +257,17 @@ Node convert<moveit_benchmark_suite::DataSet>::encode(const moveit_benchmark_sui
 
     for (const auto& data : data_map.second)
     {
-      d_node[DATASET_NAME_KEY] = data_map.first;
-      d_node[DATASET_CONFIG_KEY] = data->query->group_name_map;
+      d_node["name"] = data_map.first;
+      d_node["config"] = data->query->group_name_map;
 
       for (const auto& metric : data->metrics)
       {
-        d_node[DATA_METRIC_KEY][metric.first].push_back(metric.second);
-        d_node[DATA_METRIC_KEY][metric.first].SetStyle(EmitterStyle::Flow);
+        d_node["metrics"][metric.first].push_back(metric.second);
+        d_node["metrics"][metric.first].SetStyle(EmitterStyle::Flow);
       }
     }
     // Remove sequence if metric has only one value
-    for (YAML::iterator it = d_node[DATA_METRIC_KEY].begin(); it != d_node[DATA_METRIC_KEY].end(); ++it)
+    for (YAML::iterator it = d_node["metrics"].begin(); it != d_node["metrics"].end(); ++it)
     {
       YAML::Node value = it->second;
       if (value.Type() == YAML::NodeType::Sequence)
@@ -272,7 +282,7 @@ Node convert<moveit_benchmark_suite::DataSet>::encode(const moveit_benchmark_sui
       }
     }
 
-    node[DATASET_DATA_KEY].push_back(d_node);
+    node["data"].push_back(d_node);
   }
 
   return node;
@@ -282,28 +292,27 @@ bool convert<moveit_benchmark_suite::DataSet>::decode(const Node& node, moveit_b
 {
   using namespace moveit_benchmark_suite;
 
-  rhs.name = node[DATASET_NAME_KEY].as<std::string>();
-  rhs.type = node[DATASET_TYPE_KEY].as<std::string>();
-  rhs.uuid = node[DATASET_UUID_KEY].as<std::string>();
-  rhs.date = boost::posix_time::time_from_string(node[DATASET_DATE_KEY].as<std::string>());
-  rhs.date_utc = boost::posix_time::time_from_string(node[DATASET_DATE_UTC_KEY].as<std::string>());
-  rhs.time = node[DATASET_TOTAL_TIME_KEY].as<double>();
-  rhs.allowed_time = node[DATASET_TIME_LIMIT_KEY].as<double>();
-  rhs.trials = node[DATASET_TRIALS_KEY].as<int>();
-  rhs.hostname = node[DATASET_HOSTNAME_KEY].as<std::string>();
+  rhs.name = node["name"].as<std::string>();
+  rhs.type = node["type"].as<std::string>();
+  rhs.uuid = node["uuid"].as<std::string>();
+  rhs.date = boost::posix_time::time_from_string(node["date"].as<std::string>());
+  rhs.date_utc = boost::posix_time::time_from_string(node["date_utc"].as<std::string>());
+  rhs.time = node["total_time"].as<double>();
+  rhs.allowed_time = node["timelimit"].as<double>();
+  rhs.trials = node["trials"].as<int>();
+  rhs.hostname = node["hostname"].as<std::string>();
 
   // hw
-  rhs.cpuinfo = node[DATASET_HW_KEY]["cpu"].as<CPUInfo>();
-  rhs.gpuinfo = node[DATASET_HW_KEY]["gpu"].as<GPUInfo>();
+  rhs.cpu = node["cpu"].as<metadata::CPU>();
+  rhs.gpus = node["gpu"].as<std::vector<metadata::GPU>>();
 
   // sw
-  rhs.moveitinfo = node[DATASET_SW_KEY]["moveit"].as<RosPkgInfo>();
-  rhs.moveitbenchmarksuiteinfo = node[DATASET_SW_KEY]["moveit_benchmark_suite"].as<RosPkgInfo>();
+  rhs.sw_metadata = node["sw"].as<std::vector<metadata::SW>>();
 
   // os
-  rhs.osinfo = node[DATASET_OS_KEY].as<OSInfo>();
+  rhs.os = node["os"].as<metadata::OS>();
 
-  rhs.query_setup = node[DATASET_CONFIG_KEY].as<QuerySetup>();
+  rhs.query_setup = node["config"].as<QuerySetup>();
 
   // data
   for (YAML::const_iterator it = node["data"].begin(); it != node["data"].end(); ++it)
@@ -385,6 +394,7 @@ bool convert<moveit_benchmark_suite::DataSet>::decode(const Node& node, moveit_b
 
   return true;
 }
+
 Node convert<moveit_benchmark_suite::Metric>::encode(const moveit_benchmark_suite::Metric& rhs)
 {
   Node node;

--- a/moveit/include/moveit_benchmark_suite/profilers/collision_check_profiler.h
+++ b/moveit/include/moveit_benchmark_suite/profilers/collision_check_profiler.h
@@ -94,6 +94,7 @@ public:
   };
 
   void buildQueriesFromYAML(const std::string& filename) override;
+  std::vector<metadata::SW> getSoftwareMetadata() override;
 
   CollisionCheckResult runQuery(const CollisionCheckQuery& query, Data& result) const override;
   void postRunQuery(const CollisionCheckQuery& query, CollisionCheckResult& result, Data& data) override;

--- a/moveit/src/benchmark_callback_loader.cpp
+++ b/moveit/src/benchmark_callback_loader.cpp
@@ -62,6 +62,11 @@ BenchmarkCallbackLoader::BenchmarkCallbackLoader(Benchmark& benchmark) : benchma
 
 void BenchmarkCallbackLoader::addCallbacks(PlanningPipelineProfiler& profiler)
 {
+  // Software metadata
+  benchmark_.addPreBenchmarkCallback(
+      [&](DataSetPtr& dataset) { dataset->sw_metadata = profiler.getSoftwareMetadata(); });
+
+  // Visuals
   if (rviz_)
     profiler.addPostRunQueryCallback([&](const MotionPlanningQuery& query, MotionPlanningResult& result, Data& data) {
       rviz_->initialize(query.robot, query.scene);
@@ -84,6 +89,11 @@ void BenchmarkCallbackLoader::addCallbacks(PlanningPipelineProfiler& profiler)
 
 void BenchmarkCallbackLoader::addCallbacks(MoveGroupInterfaceProfiler& profiler)
 {
+  // Software metadata
+  benchmark_.addPreBenchmarkCallback(
+      [&](DataSetPtr& dataset) { dataset->sw_metadata = profiler.getSoftwareMetadata(); });
+
+  // Visuals
   if (rviz_)
     profiler.addPostRunQueryCallback([&](const MotionPlanningQuery& query, MotionPlanningResult& result, Data& data) {
       rviz_->initialize(query.robot, query.scene);
@@ -106,6 +116,11 @@ void BenchmarkCallbackLoader::addCallbacks(MoveGroupInterfaceProfiler& profiler)
 
 void BenchmarkCallbackLoader::addCallbacks(CollisionCheckProfiler& profiler)
 {
+  // Software metadata
+  benchmark_.addPreBenchmarkCallback(
+      [&](DataSetPtr& dataset) { dataset->sw_metadata = profiler.getSoftwareMetadata(); });
+
+  // Visuals
   if (rviz_)
     profiler.addPostRunQueryCallback([&](const CollisionCheckQuery& query, CollisionCheckResult& result, Data& data) {
       rviz_->initialize(query.robot, query.scene);

--- a/moveit/src/profilers/collision_check_profiler.cpp
+++ b/moveit/src/profilers/collision_check_profiler.cpp
@@ -63,6 +63,25 @@ CollisionCheckQuery::CollisionCheckQuery(const std::string& name,               
 CollisionCheckProfiler::CollisionCheckProfiler()
   : ProfilerTemplate<CollisionCheckQuery, CollisionCheckResult>(ProfilerType::COLLISION_CHECK){};
 
+std::vector<metadata::SW> CollisionCheckProfiler::getSoftwareMetadata()
+{
+  std::vector<metadata::SW> metadata;
+
+  // Default ROS pkg
+  metadata.push_back(IO::getROSPkgMetadata("moveit_core"));
+  metadata.push_back(IO::getROSPkgMetadata("moveit_benchmark_suite"));
+
+  // SW depending on queries
+  const auto& setup = getQuerySetup();
+
+  if (setup.hasQueryKey("collision_detector", "FCL"))
+    metadata.push_back(IO::getROSPkgMetadata("fcl"));
+  if (setup.hasQueryKey("collision_detector", "Bullet"))
+    metadata.push_back(IO::getDebianPkgMetadata("libbullet-dev"));
+
+  return metadata;
+}
+
 void CollisionCheckProfiler::buildQueriesFromYAML(const std::string& filename)
 {
   CollisionCheckBuilder builder;


### PR DESCRIPTION
Fixes #28. Retrieve metadata information from `rospack` and `dpack`. Metadata can also be retrieved from a `pluginlib` class name. This is done by adding a virtual function to profilers. It is up to each profiler to store the desired metadata.

Examples:
```yaml
- name: moveit_core
  version: 1.1.8
  pkg_manager: ROS Package
  git_branch: master
  git_commit: ee48dc5cedc981d0869352aa3db0b41469c2735c

- name: moveit_benchmark_suite
  version: 0.0.0
  pkg_manager: ROS Package
  git_branch: sw-versioning
  git_commit: e9526f95b2df35ef1a2ff39d18b49c50edfb68a4

- name: fcl
  version: 0.6.1
  pkg_manager: ROS Package

- name: libbullet-dev
  version: 2.88+dfsg-2build2
  pkg_manager: DPKG

- name: ompl
  version: 1.5.2
  pkg_manager: ROS Package
  git_branch: main
  git_commit: 528f02cdc5ac785ba24e1dbdf1cf621a17020b7b

- name: ur_kinematics
  version: 1.2.5
  pkg_manager: ROS Package
  git_branch: calibration_devel
  git_commit: 90c141b4719dd0df87baef12c46c26c374608ba1
```