### PR TITLE
Fix missing dependencies: tinyxml2 + rviz

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(Eigen3 REQUIRED)
 find_package(fcl REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
+  cmake_modules
   eigen_conversions
   moveit_core
   moveit_ros_planning
@@ -15,6 +16,8 @@ find_package(catkin REQUIRED COMPONENTS
   tf2_ros
   urdf_to_scene
 )
+
+find_package(TinyXML2 REQUIRED)
 
 catkin_package(
   LIBRARIES
@@ -34,7 +37,10 @@ catkin_package(
 
 set(CMAKE_CXX_STANDARD 14)
 
-include_directories(include ${catkin_INCLUDE_DIRS})
+include_directories(include
+  ${catkin_INCLUDE_DIRS}
+  ${TinyXML2_INCLUDE_DIRS}
+)
 
 add_library(${PROJECT_NAME}
   src/resource_builder.cpp

--- a/core/package.xml
+++ b/core/package.xml
@@ -8,6 +8,8 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 
+	<build_depend>cmake_modules</build_depend>
+
 	<depend>boost</depend>
 	<depend>eigen_conversions</depend>
 	<depend>moveit_core</depend>
@@ -15,6 +17,7 @@
 	<depend>moveit_ros_planning_interface</depend>
 	<depend>moveit_serialization</depend>
 	<depend>roscpp</depend>
+    <depend>tinyxml2</depend>
 	<depend>tf2_ros</depend>
 	<depend>urdf_to_scene</depend>
 

--- a/core/src/io.cpp
+++ b/core/src/io.cpp
@@ -15,6 +15,7 @@
 #include <boost/uuid/uuid_io.hpp>          // for UUID generation
 #include <ros/package.h>                   // for package resolving
 #include <ros/console.h>
+#include <tinyxml2.h>
 
 #include <moveit_benchmark_suite/io.h>
 #include <moveit_benchmark_suite/handler.h>

--- a/output/CMakeLists.txt
+++ b/output/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(fcl REQUIRED)
 
 find_package(catkin REQUIRED COMPONENTS
   moveit_benchmark_suite_core
+  rviz # depends only on 'SendFilePath.srv' service msg
 )
 
 catkin_package(

--- a/output/package.xml
+++ b/output/package.xml
@@ -8,6 +8,8 @@
 
 	<buildtool_depend>catkin</buildtool_depend>
 
+	<build_depend>rviz</build_depend>
+
 	<depend>moveit_benchmark_suite_core</depend>
 
 	<export>


### PR DESCRIPTION
Should fix #50.

- Fix tinyxml2 dependencies
- Fix missing rviz build dependency for `SendFilePath.srv`