### PR TITLE
Clear and stop query building from an invalid configuration

### DIFF
--- a/core/include/moveit_benchmark_suite/io.h
+++ b/core/include/moveit_benchmark_suite/io.h
@@ -227,6 +227,13 @@ void threadSleep(double seconds);
 template <typename T>
 std::vector<T> tokenize(const std::string& string, const std::string& separators = " ");
 
+/** \brief Compare valid keys against node keys
+ *  \param[in] node Node to comapre.
+ *  \param[in] keys List of keys used to compare.
+ *  \return True if keys matches node keys, false otherwise.
+ */
+bool validateNodeKeys(const YAML::Node& node, const std::vector<std::string>& keys);
+
 /** \brief Write the contents of a YAML node out to a potentially new file.
  *  \param[in] node Node to write.
  *  \param[in] file Filename to open.

--- a/core/include/moveit_benchmark_suite/resource_builder.h
+++ b/core/include/moveit_benchmark_suite/resource_builder.h
@@ -106,14 +106,18 @@ protected:
       // Compare nodes to find if everything has been converted correctly
       if (YAML::isSubset(source, target))
         return true;
+      const std::string del = "------";
+      ROS_WARN_STREAM("Source node is not a subset of target node"
+                      << "\n------\nSource\n------\n"
+                      << source << "\n------\nTarget\n------\n"
+                      << target << "\n------");
+      return false;
     }
     catch (const YAML::Exception& e)
     {
       ROS_ERROR("YAML decode exception: %s", e.what());
       return false;
     }
-
-    return false;
   }
 
 private:

--- a/core/include/moveit_benchmark_suite/resource_builder.h
+++ b/core/include/moveit_benchmark_suite/resource_builder.h
@@ -142,8 +142,18 @@ public:
 
     // Decode nodes
     for (const auto& resource : node_map)
-      requests.insert({ resource.first, resource.second["resource"].template as<T>() });
-
+    {
+      try
+      {
+        requests.insert({ resource.first, resource.second["resource"].template as<T>() });
+      }
+      catch (YAML::BadConversion& e)
+      {
+        ROS_WARN("Resource '%s' bad YAML conversion\n%s", resource.first.c_str(), e.what());
+        requests.clear();
+        return requests;
+      }
+    }
     return requests;
   };
 

--- a/core/include/moveit_benchmark_suite/resource_builder.h
+++ b/core/include/moveit_benchmark_suite/resource_builder.h
@@ -89,6 +89,7 @@ protected:
 
   const std::map<std::string, YAML::Node>& getResources() const;
   void insertResource(const std::string, const YAML::Node& node);
+  void clearResources();
 
   // Decode a node with the template type and encode to a node and check if the original is a subset
   template <typename T>

--- a/core/include/moveit_benchmark_suite/resource_builder.h
+++ b/core/include/moveit_benchmark_suite/resource_builder.h
@@ -67,7 +67,7 @@ public:
   //   - File (YAML, XML, XACRO)
   //   - ROS Parameter namespace
   //   - YAML node
-  void decodeResourceTag(const YAML::Node& source, YAML::Node& target);
+  bool decodeResourceTag(const YAML::Node& source, YAML::Node& target);
 
   // Merge supplied node to specific/all resources in the map
   void mergeResource(const std::string& name, const YAML::Node& node);
@@ -84,8 +84,8 @@ public:
   virtual bool validateResource(const YAML::Node& node);  // defaults to true
 
 protected:
-  void loadResource(const YAML::Node& node);
-  void extendResource(const YAML::Node& node, std::vector<std::string>& resource_names);
+  bool loadResource(const YAML::Node& node);
+  bool extendResource(const YAML::Node& node, std::vector<std::string>& resource_names);
 
   const std::map<std::string, YAML::Node>& getResources() const;
   void insertResource(const std::string, const YAML::Node& node);

--- a/core/src/io.cpp
+++ b/core/src/io.cpp
@@ -537,6 +537,45 @@ const bool IO::loadFileToYAML(const std::string& path, YAML::Node& node, bool ve
   return true;
 }
 
+bool IO::validateNodeKeys(const YAML::Node& node, const std::vector<std::string>& keys)
+{
+  std::size_t match_key_count = 0;
+  std::vector<std::size_t> unmatch_indexes;
+
+  std::size_t loop_ctr = 0;
+  for (const auto& key : keys)
+  {
+    if (node[key])
+      match_key_count++;
+    else
+      unmatch_indexes.push_back(loop_ctr);
+    loop_ctr++;
+  }
+
+  if (node.size() != match_key_count)
+  {
+    std::string unmatch_keys;
+    std::string del = ", ";
+
+    for (const auto& idx : unmatch_indexes)
+      unmatch_keys += "'" + keys[idx] + "'" + del;
+
+    if (!unmatch_keys.empty())
+    {
+      for (const auto& c : del)
+        unmatch_keys.pop_back();
+    }
+    const std::string KEY_STR = (unmatch_keys.size() == 1) ? "key" : "keys";
+
+    ROS_ERROR("Invalid node %s found in configuration.", KEY_STR.c_str());
+    ROS_ERROR("Unmatched valid %s: [%s]", KEY_STR.c_str(), unmatch_keys.c_str());
+    ROS_ERROR_STREAM("Node output:\n" << node);
+    return false;
+  }
+
+  return true;
+}
+
 bool IO::YAMLToFile(const YAML::Node& node, const std::string& file)
 {
   YAML::Emitter out;

--- a/core/src/resource_builder.cpp
+++ b/core/src/resource_builder.cpp
@@ -354,7 +354,7 @@ bool buildClutteredWorld(const planning_scene::PlanningScenePtr& planning_scene,
 
   collision_detection::CollisionRequest req;
   req.contacts = true;
-  req.verbose = true;
+  req.verbose = false;
   req.max_contacts = 2;
 
   Eigen::Quaterniond quat;
@@ -368,6 +368,8 @@ bool buildClutteredWorld(const planning_scene::PlanningScenePtr& planning_scene,
   planning_scene->setCurrentState(robot_state);
 
   planning_scene::PlanningScene test_scene(planning_scene->getRobotModel());
+
+  ROS_INFO("Building cluttred scene...");
 
   for (const auto& helper : helpers)
   {

--- a/core/src/resource_builder.cpp
+++ b/core/src/resource_builder.cpp
@@ -31,6 +31,11 @@ void ResourceBuilder::insertResource(const std::string name, const YAML::Node& n
     ROS_WARN("Resource name `%s` already in map.", name.c_str());
 }
 
+void ResourceBuilder::clearResources()
+{
+  node_map_.clear();
+}
+
 bool ResourceBuilder::validateResource(const YAML::Node& node)
 {
   return true;

--- a/core/src/resource_builder.cpp
+++ b/core/src/resource_builder.cpp
@@ -483,6 +483,10 @@ bool SceneBuilder::buildClutteredSceneFromYAML(ScenePtr& scene,
                                                const std::map<std::string, moveit_msgs::RobotState>& state_map,
                                                const YAML::Node& node) const
 {
+  if (!IO::validateNodeKeys(node, { "object_in_collision", "object_no_collision", "rng_in_collision",
+                                    "rng_no_collision", "bounds", "resource", "robot_state", "object_type" }))
+    return false;
+
   std::size_t in_object_size = node["object_in_collision"].as<std::size_t>(0);
   std::size_t free_object_size = node["object_no_collision"].as<std::size_t>(0);
 

--- a/core/src/robot.cpp
+++ b/core/src/robot.cpp
@@ -87,6 +87,10 @@ bool Robot::initialize(const std::string& urdf_file, const std::string& srdf_fil
 }
 bool Robot::initializeFromYAML(const YAML::Node& node)
 {
+  // Strict config keys
+  if (!IO::validateNodeKeys(node, { "urdf", "srdf", "kinematics", "joint_limits" }))
+    return false;
+
   if (loader_)
   {
     ROS_ERROR("Already initialized!");


### PR DESCRIPTION
Stop and clear the resource builder when an error occurs. This also adds better verbosity when a configuration has errors.

TODO:
- [x] Guard against multiple node keys access, e.g. node["key1"]["key2"]
- [x] return error in `decodeResourceTag` 