### PR TITLE
Add dependency on rviz for config service description

### DIFF
--- a/moveit/CMakeLists.txt
+++ b/moveit/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(Boost REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   moveit_benchmark_suite_core
   moveit_benchmark_suite_output
+  rviz
 )
 
 catkin_package(


### PR DESCRIPTION
I'm a bit confused why you don't need this? I'm running on noetic with rviz in my workspace