### PR TITLE
Default to `PNG` format when generating multiple plots

### DIFF
--- a/moveit/plots/collision_checks.yaml
+++ b/moveit/plots/collision_checks.yaml
@@ -279,7 +279,7 @@ gnuplot_config:
           name: avg_contact_count
           title: '{/:Bold Collision (Self + Environment)}\nCountact count (mean) for scene \"mesh-100-4c\" against requests and collision detectors'
   options:
-    terminal: SVG
+    terminal: PNG
     n_row: 1
     n_col: 1
     size:

--- a/tools/include/moveit_benchmark_suite/tools/gnuplot.h
+++ b/tools/include/moveit_benchmark_suite/tools/gnuplot.h
@@ -61,6 +61,7 @@ MOVEIT_CLASS_FORWARD(GNUPlotTerminal);
 
 static std::string TERMINAL_QT_STR = "qt";
 static std::string TERMINAL_SVG_STR = "svg";
+static std::string TERMINAL_PNG_STR = "png";
 
 struct TerminalSize
 {
@@ -106,6 +107,19 @@ public:
   /** \brief Virtual destructor for cleaning up resources.
    */
   ~SvgTerminal() override;
+
+  // Get GNUPlot command as a string
+  std::string getCmd() const override;
+};
+
+// Produces files in the W3C Scalable Vector Graphics format
+class PngTerminal : public GNUPlotTerminal
+{
+public:
+  PngTerminal();
+  /** \brief Virtual destructor for cleaning up resources.
+   */
+  ~PngTerminal() override;
 
   // Get GNUPlot command as a string
   std::string getCmd() const override;

--- a/tools/include/moveit_benchmark_suite/tools/gnuplot.h
+++ b/tools/include/moveit_benchmark_suite/tools/gnuplot.h
@@ -117,7 +117,7 @@ public:
   std::string getCmd() const override;
 };
 
-// Produces files in the W3C Scalable Vector Graphics format
+// Produces files in the Portable Network Graphics format
 class PngTerminal : public GNUPlotTerminal
 {
 public:
@@ -188,20 +188,23 @@ public:
   GNUPlotHelper(GNUPlotHelper const&) = delete;
   void operator=(GNUPlotHelper const&) = delete;
 
-  struct InstanceOptions
+  struct GNUPlotOptions
   {
     std::string instance{ "default" };
   };
 
   std::set<std::string> getInstanceNames() const;
+
   void getInstanceOutput(const std::string& instance, std::string& output);
+
+  std::shared_ptr<GNUPlotTerminal> getInstanceTerminal(const std::string& instance);
 
   void configureTerminal(const std::string& instance_id, const GNUPlotTerminal& terminal);
 
   /** \name Plotting
       \{ */
 
-  struct PlottingOptions : InstanceOptions
+  struct PlottingOptions : GNUPlotOptions
   {
     struct Axis
     {
@@ -255,7 +258,7 @@ public:
    */
   void plot(const GNUPlotData& data, const BarGraphOptions& options);
 
-  struct MultiPlotOptions : InstanceOptions
+  struct MultiPlotOptions : GNUPlotOptions
   {
     struct Layout
     {
@@ -283,6 +286,8 @@ private:
 
     ~Instance();
 
+    void setTerminal(std::shared_ptr<GNUPlotTerminal> terminal);
+    std::shared_ptr<GNUPlotTerminal> getTerminal();
     /** \name Raw Input
         \{ */
 
@@ -299,6 +304,8 @@ private:
     // non-copyable
     Instance(Instance const&) = delete;
     void operator=(Instance const&) = delete;
+
+    std::shared_ptr<GNUPlotTerminal> terminal_;
 
     bool debug_{ false };
 
@@ -320,7 +327,10 @@ private:
    *  \param[in] name Name of instance.
    *  \return The instance.
    */
+public:
   std::shared_ptr<Instance> getInstance(const std::string& name);
+
+private:
   std::map<std::string, std::shared_ptr<Instance>> instances_;  ///< Map of open GNUPlot instances
 };
 
@@ -380,6 +390,7 @@ public:
 
   std::set<std::string> getInstanceNames() const;
   void getInstanceOutput(const std::string& instance_name, std::string& output);
+  std::shared_ptr<GNUPlotTerminal> getInstanceTerminal(const std::string& instance_name);
 
 private:
   // Filtered dataset

--- a/tools/include/moveit_benchmark_suite/tools/gnuplot.h
+++ b/tools/include/moveit_benchmark_suite/tools/gnuplot.h
@@ -63,6 +63,9 @@ static std::string TERMINAL_QT_STR = "qt";
 static std::string TERMINAL_SVG_STR = "svg";
 static std::string TERMINAL_PNG_STR = "png";
 
+static std::string TERMINAL_SVG_FILE_EXT = "svg";
+static std::string TERMINAL_PNG_FILE_EXT = "png";
+
 struct TerminalSize
 {
   double x = 640;
@@ -73,7 +76,7 @@ struct TerminalSize
 class GNUPlotTerminal
 {
 public:
-  GNUPlotTerminal(const std::string& mode);
+  GNUPlotTerminal(const std::string& mode, const std::string& file_ext = "");
 
   /** \brief Virtual destructor for cleaning up resources.
    */
@@ -84,6 +87,8 @@ public:
 
   const std::string mode;
   TerminalSize size;
+
+  std::string file_ext;
 };
 
 // Generates output in a separate window with the Qt library

--- a/tools/include/moveit_benchmark_suite/tools/htmlplot.h
+++ b/tools/include/moveit_benchmark_suite/tools/htmlplot.h
@@ -49,6 +49,13 @@ class HTMLPlot
 public:
   HTMLPlot(const std::string& pathname);
 
+  std::string getFilepath()
+  {
+    return abs_path_;
+  };
+
+  void writeImageTag(const std::string& src);
+
   void write(const std::string& line);
   void writeline(const std::string& line);
   void flush();

--- a/tools/src/generate_plots.cpp
+++ b/tools/src/generate_plots.cpp
@@ -45,9 +45,11 @@ int main(int argc, char** argv)
     std::ofstream ofs;
     boost::filesystem::path path(html_filepath);
 
-    // add to html_filepath folder name (without the extension)
+    auto terminal = gnuplot.getInstanceTerminal(name);
+
+    // prepare terminal output filename
     path.replace_extension("");
-    path /= name + ".png";
+    path /= name + "." + terminal->file_ext;
 
     IO::createFile(ofs, path.string());
     std::string output;

--- a/tools/src/generate_plots.cpp
+++ b/tools/src/generate_plots.cpp
@@ -35,15 +35,28 @@ int main(int argc, char** argv)
 
   // Add GNUPlot instances into HTML
   HTMLPlot html(output_file);
-  auto names = gnuplot.getInstanceNames();
+  auto html_filepath = html.getFilepath();
+  auto instance_names = gnuplot.getInstanceNames();
 
   ROS_INFO("Generating HTML file...");
 
-  for (const auto& name : names)
+  for (const auto& name : instance_names)
   {
+    std::ofstream ofs;
+    boost::filesystem::path path(html_filepath);
+
+    // add to html_filepath folder name (without the extension)
+    path.replace_extension("");
+    path /= name + ".png";
+
+    IO::createFile(ofs, path.string());
     std::string output;
     gnuplot.getInstanceOutput(name, output);
-    html.writeline(output);
+    ofs << output;
+    ofs.close();
+
+    // add image source
+    html.writeImageTag(path.string());
   }
 
   html.dump();

--- a/tools/src/gnuplot.cpp
+++ b/tools/src/gnuplot.cpp
@@ -62,6 +62,23 @@ std::string SvgTerminal::getCmd() const
 }
 
 ///
+/// PngTerminal
+///
+
+PngTerminal::PngTerminal() : GNUPlotTerminal(TERMINAL_PNG_STR)
+{
+}
+
+PngTerminal::~PngTerminal()
+{
+}
+
+std::string PngTerminal::getCmd() const
+{
+  return log::format("set term %1% size %2%,%3%", mode, size.x, size.y);
+}
+
+///
 /// GNUPlotData
 ///
 
@@ -626,6 +643,8 @@ bool GNUPlotDataset::initializeFromYAML(const std::string& file)
       layout.terminal = std::make_shared<QtTerminal>();
     else if (terminal_type.compare("SVG") == 0)
       layout.terminal = std::make_shared<SvgTerminal>();
+    else if (terminal_type.compare("PNG") == 0)
+      layout.terminal = std::make_shared<PngTerminal>();
     else
       layout.terminal = std::make_shared<QtTerminal>();
 

--- a/tools/src/gnuplot.cpp
+++ b/tools/src/gnuplot.cpp
@@ -646,7 +646,10 @@ bool GNUPlotDataset::initializeFromYAML(const std::string& file)
     else if (terminal_type.compare("PNG") == 0)
       layout.terminal = std::make_shared<PngTerminal>();
     else
+    {
+      ROS_WARN_STREAM("Invalid GNUPlot terminal '" << terminal_type << "' in config, using default QT terminal.");
       layout.terminal = std::make_shared<QtTerminal>();
+    }
 
     layout.terminal->size.x = 640;
     layout.terminal->size.y = 480;

--- a/tools/src/gnuplot.cpp
+++ b/tools/src/gnuplot.cpp
@@ -25,7 +25,8 @@ namespace bio = boost::iostreams;
 /// GNUPlotTerminal
 ///
 
-GNUPlotTerminal::GNUPlotTerminal(const std::string& mode) : mode(mode){};
+GNUPlotTerminal::GNUPlotTerminal(const std::string& mode, const std::string& file_ext)
+  : mode(mode), file_ext(file_ext){};
 
 ///
 /// QtTerminal
@@ -48,7 +49,7 @@ std::string QtTerminal::getCmd() const
 /// SvgTerminal
 ///
 
-SvgTerminal::SvgTerminal() : GNUPlotTerminal(TERMINAL_SVG_STR)
+SvgTerminal::SvgTerminal() : GNUPlotTerminal(TERMINAL_SVG_STR, TERMINAL_SVG_FILE_EXT)
 {
 }
 
@@ -65,7 +66,7 @@ std::string SvgTerminal::getCmd() const
 /// PngTerminal
 ///
 
-PngTerminal::PngTerminal() : GNUPlotTerminal(TERMINAL_PNG_STR)
+PngTerminal::PngTerminal() : GNUPlotTerminal(TERMINAL_PNG_STR, TERMINAL_PNG_FILE_EXT)
 {
 }
 

--- a/tools/src/gnuplot.cpp
+++ b/tools/src/gnuplot.cpp
@@ -225,6 +225,16 @@ GNUPlotHelper::Instance::~Instance()
   th_.detach();
 }
 
+void GNUPlotHelper::Instance::setTerminal(std::shared_ptr<GNUPlotTerminal> terminal)
+{
+  terminal_ = terminal;
+}
+
+std::shared_ptr<GNUPlotTerminal> GNUPlotHelper::Instance::getTerminal()
+{
+  return terminal_;
+}
+
 void GNUPlotHelper::Instance::write(const std::string& line)
 {
 #if IS_BOOST_164
@@ -285,6 +295,12 @@ void GNUPlotHelper::getInstanceOutput(const std::string& instance, std::string& 
 
   for (std::string line; std::getline(is, line);)
     output.append(line + "\n");
+}
+
+std::shared_ptr<GNUPlotTerminal> GNUPlotHelper::getInstanceTerminal(const std::string& instance)
+{
+  auto in = getInstance(instance);
+  return in->getTerminal();
 }
 
 void GNUPlotHelper::configureTerminal(const std::string& instance_id, const GNUPlotTerminal& terminal)
@@ -1048,6 +1064,11 @@ void GNUPlotDataset::plot(const MultiPlotLayout& layout, const DatasetFilter::Da
       case PlotType::BarGraph:
       {
         auto options = std::static_pointer_cast<GNUPlotHelper::BarGraphOptions>(c.first.options);
+
+        // set terminal used by instance
+        auto in = helper_.getInstance(options->instance);
+        in->setTerminal(layout_.terminal);
+
         if (!single_instance_)
           helper_.configureTerminal(options->instance, *layout_.terminal);
         helper_.plot(c.second, *options);
@@ -1056,6 +1077,11 @@ void GNUPlotDataset::plot(const MultiPlotLayout& layout, const DatasetFilter::Da
       case PlotType::BoxPlot:
       {
         auto options = std::static_pointer_cast<GNUPlotHelper::BoxPlotOptions>(c.first.options);
+
+        // set terminal used by instance
+        auto in = helper_.getInstance(options->instance);
+        in->setTerminal(layout_.terminal);
+
         if (!single_instance_)
           helper_.configureTerminal(options->instance, *layout_.terminal);
         helper_.plot(c.second, *options);
@@ -1073,4 +1099,9 @@ std::set<std::string> GNUPlotDataset::getInstanceNames() const
 void GNUPlotDataset::getInstanceOutput(const std::string& instance_name, std::string& output)
 {
   helper_.getInstanceOutput(instance_name, output);
+}
+
+std::shared_ptr<GNUPlotTerminal> GNUPlotDataset::getInstanceTerminal(const std::string& instance_name)
+{
+  return helper_.getInstanceTerminal(instance_name);
 }

--- a/tools/src/htmlplot.cpp
+++ b/tools/src/htmlplot.cpp
@@ -32,7 +32,7 @@ HTMLPlot::HTMLPlot(const std::string& pathname)
 
   // CSS: set SVG stacked and horizontally centered
   writeline("<style>");
-  writeline("svg {");
+  writeline("img {");
   writeline("display: flex;");
   writeline("justify-content: center;");
   writeline("align-items: center;");
@@ -40,6 +40,11 @@ HTMLPlot::HTMLPlot(const std::string& pathname)
   writeline("}");
   writeline("</style>");
 };
+
+void HTMLPlot::writeImageTag(const std::string& src)
+{
+  writeline("<img src=\"" + src + "\">");
+}
 
 void HTMLPlot::write(const std::string& line)
 {


### PR DESCRIPTION
Default to `PNG` format which is really small compared to complex `SVG` (boxplots with large dataset). The HTML will load the images much faster. 

TODO:
- [x] Switch embedded svg's to references.
- [x] Add images to a folder.
- [x] Add PNG GNUPlot terminal.
- [x] Retrieve the terminal from a GNUPlot instance to find the extension of the output file. 