### PR TITLE
[ROS-O] do not enforce c++ standard

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -35,8 +35,6 @@ catkin_package(
     urdf_to_scene
 )
 
-set(CMAKE_CXX_STANDARD 14)
-
 include_directories(include
   ${catkin_INCLUDE_DIRS}
   ${TinyXML2_INCLUDE_DIRS}

--- a/moveit/CMakeLists.txt
+++ b/moveit/CMakeLists.txt
@@ -18,8 +18,6 @@ catkin_package(
     moveit_benchmark_suite_tools
 )
 
-set(CMAKE_CXX_STANDARD 14)
-
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}

--- a/mtc/CMakeLists.txt
+++ b/mtc/CMakeLists.txt
@@ -12,8 +12,6 @@ find_package(catkin REQUIRED COMPONENTS
 
 catkin_package()
 
-set(CMAKE_CXX_STANDARD 14)
-
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -20,8 +20,6 @@ catkin_package(
     rviz
 )
 
-set(CMAKE_CXX_STANDARD 14)
-
 include_directories(include ${catkin_INCLUDE_DIRS})
 
 add_library(${PROJECT_NAME}


### PR DESCRIPTION
At least c++14 is the default in gcc/clang at the moment. log4cxx requires c++17 and forcing an old standard breaks the build.

Required for ROS-O.