### PR TITLE
Fix default motion planning benchmark + plots

### DIFF
--- a/moveit/config/motion_planning_mgi.yaml
+++ b/moveit/config/motion_planning_mgi.yaml
@@ -20,40 +20,42 @@ profiler_config:
 
   # Resource moveit_msgs/MotionPlanRequest
   requests:
-    # - name: jc
-    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/jc.yaml
-    - name: poc-blk01
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk01.yaml
-    - name: poc-blk02
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk02.yaml
-    - name: poc-blk03
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk03.yaml
-    - name: poc-blk04
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk04.yaml
-    - name: poc-blk05
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk05.yaml
-    - name: poc-blk06
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk06.yaml
-    - name: poc-blk07
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk07.yaml
-    - name: poc-blk08
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk08.yaml
-    - name: poc-blk09
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk09.yaml
-    - name: poc-blk10
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk10.yaml
-    - name: poc-blk11
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk11.yaml
-    - name: poc-blk12
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk12.yaml
-    - name: poc-blk13
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk13.yaml
-    - name: poc-blk14
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk14.yaml
-    - name: poc-blk15
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk15.yaml
-    - name: poc-blk16
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk16.yaml
+    - name: jc
+      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/jc.yaml
+
+    # Cartesian goals to pre-grasp each block/cube
+    #- name: poc-blk01
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk01.yaml
+    #- name: poc-blk02
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk02.yaml
+    #- name: poc-blk03
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk03.yaml
+    #- name: poc-blk04
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk04.yaml
+    #- name: poc-blk05
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk05.yaml
+    #- name: poc-blk06
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk06.yaml
+    #- name: poc-blk07
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk07.yaml
+    #- name: poc-blk08
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk08.yaml
+    #- name: poc-blk09
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk09.yaml
+    #- name: poc-blk10
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk10.yaml
+    #- name: poc-blk11
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk11.yaml
+    #- name: poc-blk12
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk12.yaml
+    #- name: poc-blk13
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk13.yaml
+    #- name: poc-blk14
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk14.yaml
+    #- name: poc-blk15
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk15.yaml
+    #- name: poc-blk16
+    #  resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk16.yaml
 
   # Resource moveit_config (robot)
   robot:
@@ -89,12 +91,12 @@ profiler_config:
       resource: /move_group/planning_pipelines/ompl
       parameters:
         planners:
-          - RRT
+          # - RRT
           - RRTConnect
-          - EST
-          - PRM
-          - LBKPIECE
-          - BiEST
+          # - EST
+          # - PRM
+          # - LBKPIECE
+          # - BiEST
     # - name: chomp
     #   resource: /move_group/planning_pipelines/chomp
     #   parameters:

--- a/moveit/config/motion_planning_pp.yaml
+++ b/moveit/config/motion_planning_pp.yaml
@@ -20,40 +20,42 @@ profiler_config:
 
   # Resource moveit_msgs/MotionPlanRequest
   requests:
-    # - name: jc
-    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/jc.yaml
-    - name: poc-blk01
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk01.yaml
-    - name: poc-blk02
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk02.yaml
-    - name: poc-blk03
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk03.yaml
-    - name: poc-blk04
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk04.yaml
-    - name: poc-blk05
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk05.yaml
-    - name: poc-blk06
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk06.yaml
-    - name: poc-blk07
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk07.yaml
-    - name: poc-blk08
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk08.yaml
-    - name: poc-blk09
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk09.yaml
-    - name: poc-blk10
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk10.yaml
-    - name: poc-blk11
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk11.yaml
-    - name: poc-blk12
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk12.yaml
-    - name: poc-blk13
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk13.yaml
-    - name: poc-blk14
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk14.yaml
-    - name: poc-blk15
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk15.yaml
-    - name: poc-blk16
-      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk16.yaml
+    - name: jc
+      resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/jc.yaml
+
+    # Cartesian goals to pre-grasp each block/cube
+    # - name: poc-blk01
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk01.yaml
+    # - name: poc-blk02
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk02.yaml
+    # - name: poc-blk03
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk03.yaml
+    # - name: poc-blk04
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk04.yaml
+    # - name: poc-blk05
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk05.yaml
+    # - name: poc-blk06
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk06.yaml
+    # - name: poc-blk07
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk07.yaml
+    # - name: poc-blk08
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk08.yaml
+    # - name: poc-blk09
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk09.yaml
+    # - name: poc-blk10
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk10.yaml
+    # - name: poc-blk11
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk11.yaml
+    # - name: poc-blk12
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk12.yaml
+    # - name: poc-blk13
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk13.yaml
+    # - name: poc-blk14
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk14.yaml
+    # - name: poc-blk15
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk15.yaml
+    # - name: poc-blk16
+    #   resource: package://moveit_benchmark_suite_resources/requests/bbt/panda/poc_blk16.yaml
 
   # Resource moveit_config (robot)
   robot:
@@ -85,18 +87,18 @@ profiler_config:
   # - Override the 'requests' pipeline_id field
   # - Extends query 'planners' which overrides the 'requests' planner_id field
   planning_pipelines:
-    # - name: ompl
-    #   resource: package://moveit_benchmark_suite_resources/robots/panda/config/ompl_planning.yaml
-    #   parameters:
-    #     planners:
-    #       - RRT
-    #       - RRTConnect
-    #       - EST
-    #       - PRM
-    #       - LBKPIECE
-    #       - BiEST
-    - name: chomp
-      resource: package://moveit_benchmark_suite_resources/robots/panda/config/chomp_planning.yaml
+    - name: ompl
+      resource: package://moveit_benchmark_suite_resources/robots/panda/config/ompl_planning.yaml
       parameters:
         planners:
-          - CHOMP
+          #- RRT
+          - RRTConnect
+          #- EST
+          #- PRM
+          #- LBKPIECE
+          #- BiEST
+    # - name: chomp
+    #   resource: package://moveit_benchmark_suite_resources/robots/panda/config/chomp_planning.yaml
+    #   parameters:
+    #     planners:
+    #       - CHOMP

--- a/moveit/plots/collision_checks.yaml
+++ b/moveit/plots/collision_checks.yaml
@@ -360,7 +360,7 @@ gnuplot_config:
     #       name: avg_contact_count
     #       title: '{/:Bold Collision (Self + Environment)}\nCountact count (mean) for request \"All (Cost)\" against scenes and collision detector \"FCL\"'
   options:
-    terminal: PNG
+    terminal: QT
     n_row: 1
     n_col: 1
     size:

--- a/moveit/plots/collision_checks.yaml
+++ b/moveit/plots/collision_checks.yaml
@@ -1,6 +1,13 @@
 # create HTML containing multiple pictures
 # ex. use with the default collision check benchmark
 gnuplot_config:
+  options:
+    terminal: QT
+    n_row: 1
+    n_col: 1
+    size:
+      x: 800
+      y: 480
   plots:
     # individual requests wrt. scenes and collision detectors
     - filters:
@@ -359,10 +366,3 @@ gnuplot_config:
     #     - type: bargraph
     #       name: avg_contact_count
     #       title: '{/:Bold Collision (Self + Environment)}\nCountact count (mean) for request \"All (Cost)\" against scenes and collision detector \"FCL\"'
-  options:
-    terminal: QT
-    n_row: 1
-    n_col: 1
-    size:
-      x: 800
-      y: 480

--- a/moveit/plots/collision_checks_mesh_quality.yaml
+++ b/moveit/plots/collision_checks_mesh_quality.yaml
@@ -1,6 +1,13 @@
 # create HTML containing multiple pictures
 # ex. use with the `collision_check_mesh_quality` benchmark
 gnuplot_config:
+  options:
+    terminal: QT
+    n_row: 1
+    n_col: 1
+    size:
+      x: 800
+      y: 480
   plots:
     # individual requests wrt. scenes, FCL and robot with mesh qualities
     - filters:
@@ -300,10 +307,3 @@ gnuplot_config:
         - type: bargraph
           name: avg_contact_count
           title: '{/:Bold Collision (Self + Environment)}\nCountact count (mean) for request \"All (Distance)\" against scenes and collision detector \"Bullet\"'
-  options:
-    terminal: QT
-    n_row: 1
-    n_col: 1
-    size:
-      x: 800
-      y: 480

--- a/moveit/plots/collision_checks_mesh_quality.yaml
+++ b/moveit/plots/collision_checks_mesh_quality.yaml
@@ -301,7 +301,7 @@ gnuplot_config:
           name: avg_contact_count
           title: '{/:Bold Collision (Self + Environment)}\nCountact count (mean) for request \"All (Distance)\" against scenes and collision detector \"Bullet\"'
   options:
-    terminal: PNG
+    terminal: QT
     n_row: 1
     n_col: 1
     size:

--- a/moveit/plots/motion_planning_pp_mesh_quality.yaml
+++ b/moveit/plots/motion_planning_pp_mesh_quality.yaml
@@ -1,6 +1,13 @@
 # create HTML containing multiple pictures
 # ex. use with the `collision_check_mesh_quality` benchmark
 gnuplot_config:
+  options:
+    terminal: QT
+    n_row: 1
+    n_col: 1
+    size:
+      x: 800
+      y: 480
   plots:
     # individual requests wrt. scenes, FCL and robot with mesh qualities
     - filters:
@@ -58,10 +65,3 @@ gnuplot_config:
         - type: bargraph
           name: avg_correct
           title: '{/:Bold Motion Planning (PlanningPiepeline)}\nCorrectness average (pass/fail) for planner \"CHOMP\" against scenes and collision detector \"FCL\"'
-  options:
-    terminal: QT
-    n_row: 1
-    n_col: 1
-    size:
-      x: 800
-      y: 480

--- a/moveit/plots/motion_planning_pp_mesh_quality.yaml
+++ b/moveit/plots/motion_planning_pp_mesh_quality.yaml
@@ -59,7 +59,7 @@ gnuplot_config:
           name: avg_correct
           title: '{/:Bold Motion Planning (PlanningPiepeline)}\nCorrectness average (pass/fail) for planner \"CHOMP\" against scenes and collision detector \"FCL\"'
   options:
-    terminal: PNG
+    terminal: QT
     n_row: 1
     n_col: 1
     size:

--- a/tools/src/aggregate_dataset.cpp
+++ b/tools/src/aggregate_dataset.cpp
@@ -66,6 +66,12 @@ int main(int argc, char** argv)
   pnh.getParam(OUTPUT_PARAMETER, output_file);
   pnh.getParam(CONFIG_PARAMETER, config_file);
 
+  if (input_files.empty())
+  {
+    ROS_WARN("No dataset found. The `input_files` parameter MUST be an array :");
+    ROS_WARN("    e.g. input_files:=\"[my/dataset.yaml]\"");
+  }
+
   // Aggregate datasets
   std::vector<AggregateDataset::Operation> operations;
   std::vector<Filter> filters;

--- a/tools/src/convert_dataset.cpp
+++ b/tools/src/convert_dataset.cpp
@@ -65,6 +65,12 @@ int main(int argc, char** argv)
   pnh.getParam(INPUT_PARAMETER, input_files);
   pnh.getParam(CONVERSION_PARAMETER, conversion);
 
+  if (input_files.empty())
+  {
+    ROS_WARN("No dataset found. The `input_files` parameter MUST be an array :");
+    ROS_WARN("    e.g. input_files:=\"[my/dataset.yaml]\"");
+  }
+
   // validate extension
   if (conversion.compare("json") != 0)
   {

--- a/tools/src/generate_plots.cpp
+++ b/tools/src/generate_plots.cpp
@@ -27,6 +27,12 @@ int main(int argc, char** argv)
   pnh.getParam(OUTPUT_PARAMETER, output_file);
   pnh.getParam(CONFIG_PARAMETER, config_file);
 
+  if (dataset_files.empty())
+  {
+    ROS_WARN("No dataset found. The `input_files` parameter MUST be an array :");
+    ROS_WARN("    e.g. input_files:=\"[my/dataset.yaml]\"");
+  }
+
   // Generate GNUPlot script
   GNUPlotDataset gnuplot;
 

--- a/tools/src/plot_dataset.cpp
+++ b/tools/src/plot_dataset.cpp
@@ -22,6 +22,12 @@ int main(int argc, char** argv)
   pnh.getParam(INPUT_PARAMETER, dataset_files);
   pnh.getParam(CONFIG_PARAMETER, config_file);
 
+  if (dataset_files.empty())
+  {
+    ROS_WARN("No dataset found. The `input_files` parameter MUST be an array :");
+    ROS_WARN("    e.g. input_files:=\"[my/dataset.yaml]\"");
+  }
+
   // Plot dataset
   GNUPlotDataset gnuplot;
 


### PR DESCRIPTION
Fixes #90 and #91.

TODO:
- [x] Modify benchmark config for motion planning (pp + mgi)
- [x] Modify plots config, change PNG -> QT terminal
- [x] Handle empty parameters for every node and warn user.