### PR TITLE
Pick and place benchmark fails

### DIFF
--- a/mtc/config/pickplace.yaml
+++ b/mtc/config/pickplace.yaml
@@ -42,7 +42,7 @@ profiler_config:
     grasp_frame_transform: [0.0441, -0.0441, 0.1, 1.5707, -2.356, 1.5707]
 
     # Place pose [x,y,z,r,p,y]
-    place_pose: [0, 0, 0.01, 0, 0, 0]
+    place_pose: [0, 0, 0.01, 0, 0, 3.1415]
     place_surface_offset: 0.0001 # place offset from table
 
     # Valid distance range when approaching an object for picking


### PR DESCRIPTION
Upgraded to the latest MoveIt and MTC commits and noticed that the pick and place benchmark fails. Changing the orientation of the `GeneratePlacePose` stage by half the rotation in the z-axis solves this issue. 

@v4hn Did you notice something in MoveIt or MTC that could have changed the behavior ?

With applied fix:
![image](https://user-images.githubusercontent.com/32679594/204360619-9177cc83-a73c-4004-86d3-b59e23305f65.png)
