### PR TITLE
Dataset structure

### DIFF
--- a/core/src/dataset_filter.cpp
+++ b/core/src/dataset_filter.cpp
@@ -41,7 +41,7 @@ ryml::substr loadDataset(const std::string& filename, ryml::NodeRef& root, Datas
     // partial validation of nodes
     if (not(root[i].has_child("dataset") && root[i]["dataset"].has_child("uuid")))
     {
-      ROS_WARN("Dataset malformed in file ''%s' for sequence #%zu", filename.c_str(), num_file);
+      ROS_WARN("Dataset malformed in file '%s' for sequence #%zu", filename.c_str(), num_file);
       continue;
     }
 

--- a/tools/src/aggregate.cpp
+++ b/tools/src/aggregate.cpp
@@ -12,21 +12,20 @@ DataSetPtr AggregateDataset::aggregate(const std::vector<Operation>& operations,
 {
   ryml::Tree t;
   auto node = t.rootref();
-  node |= ryml::MAP;
 
-  node.tree()->merge_with(dataset.tree(), dataset.id(), node.append_child().id());
+  node.tree()->merge_with(dataset.tree(), dataset.id(), node.id());
 
-  if (!node.has_child("dataset") || !node["dataset"].has_child("data") || !node["dataset"].has_child("type"))
+  if (!node.has_child("type"))
     return nullptr;
 
   // Add comment that this dataset was aggregated
   std::string type_str;
-  ryml::from_chars(node["dataset"]["type"].val(), &type_str);
+  ryml::from_chars(node["type"].val(), &type_str);
 
-  node["dataset"]["type"] << "[AGGREGATED] " + type_str;
+  node["type"] << "[AGGREGATED] " + type_str;
 
   // Loop through data
-  auto queries = node["dataset"]["data"];
+  auto queries = node["data"];
 
   for (std::size_t i = 0; i < queries.num_children(); ++i)
   {
@@ -110,7 +109,7 @@ DataSetPtr AggregateDataset::aggregate(const std::vector<Operation>& operations,
     }
   }
   DataSet ds;
-  node["dataset"] >> ds;
+  node >> ds;
 
   return std::make_shared<DataSet>(ds);
 }

--- a/tools/src/convert_dataset.cpp
+++ b/tools/src/convert_dataset.cpp
@@ -92,23 +92,25 @@ int main(int argc, char** argv)
       continue;
     }
 
-    if (node.is_seq())
+    if (node.is_stream())
     {
-      for (ryml::ConstNodeRef const& child : node.children())
+      for (ryml::ConstNodeRef const& doc : node.children())
       {
         std::string prefix;
-        ryml::from_chars(child["dataset"]["name"].val(), &prefix);
+        if (doc.has_child("name"))
+          ryml::from_chars(doc["name"].val(), &prefix);
 
-        // randome filename with benchmark name as prefix
-        outputer.dump(child, "", prefix);
+        // random filename with benchmark name as prefix
+        outputer.dump(doc, "", prefix);
       }
     }
     else
     {
       std::string prefix;
-      ryml::from_chars(node["dataset"]["name"].val(), &prefix);
+      if (node.has_child("name"))
+        ryml::from_chars(node["name"].val(), &prefix);
 
-      // randome filename with benchmark name as prefix
+      // random filename with benchmark name as prefix
       outputer.dump(node, "", prefix);
     }
   }

--- a/tools/src/gnuplot.cpp
+++ b/tools/src/gnuplot.cpp
@@ -806,23 +806,7 @@ std::string GNUPlotDataset::combineTokenNodeValue(const Token& token, const ryml
   ryml::Tree t;
   ryml::NodeRef scalar = t.rootref();
 
-  // add dataset keymap
-  ryml::Tree t1;
-  ryml::NodeRef token_node = t1.rootref();
-
-  if (token.isAbsolute())
-  {
-    token_node |= ryml::MAP;
-    token_node.append_child() << ryml::key("dataset") |= ryml::KEYMAP;
-    auto lc = token_node.last_child();
-
-    auto token_tree = token.getNode().tree();
-
-    t1.merge_with(token_tree, token_tree->root_id(), lc.id());
-    bool rc = c4::yml::getNodeFromKeyChainVal(token_node.first_child(), node, scalar);
-  }
-  else
-    bool rc = c4::yml::getNodeFromKeyChainVal(token.getNode(), node, scalar);
+  c4::yml::getNodeFromKeyChainVal(token.getNode(), node, scalar);
 
   if (scalar.is_val() || scalar.is_keyval())
   {


### PR DESCRIPTION
Fixes #62.

```yaml
---
name: Demo
type: Motion Planning (PlanningPipeline)
date: '2023-Mar-07 18:12:18.393036'
uuid: f81a9b2a_1a0f_4650_a099_957eccb78d60
hostname: 'captain-yoshi'
trials: 1
timelimit: 0
totaltime: 2.12926
os:
  kernel_name: Linux
  kernel_release: '5.15.0-60-generic'
  distribution: Ubuntu
  version: 20.04.5 LTS (Focal Fossa)
cpu:
  model: 158
  model_name: 'Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz'
  family: 6
  vendor_id: GenuineIntel
  architecture: x86_64
  sockets: 1
  core_per_socket: 4
  thread_per_core: 2
gpus:
  'GP106M [GeForce GTX 1060 Mobile]':
    vendor: NVIDIA Corporation
    version: a1
  HD Graphics 630:
    vendor: Intel Corporation
    version: 04
software:
  moveit_core:
    version: 1.1.10
    git_branch: HEAD
    git_commit: f4040d0468ca29546a2fd9505acc774c6e658ed0
    pkg_manager: ROS Package
  moveit_benchmark_suite:
    version: 0.0.0
    git_branch: 'dataset-refactor'
    git_commit: 0e04aa33841aa9f683030831305779e1c1f9505b
    pkg_manager: ROS Package
  fcl:
    version: 0.6.1
    pkg_manager: ROS Package
  'libbullet-dev':
    version: '2.88+dfsg-2build2'
    pkg_manager: DPKG
  ompl:
    version: 1.5.2
    git_branch: main
    git_commit: d8375d842a7f016d64f27a81d6f95eaa83fbe595
    pkg_manager: ROS Package
queries:
  collision_detector:
    - Bullet
    - FCL
  pipeline:
    - ompl
  planner:
    - RRTConnect
  request:
    - jc
  robot:
    - panda
  scene:
    - empty
data:
  - query:
      collision_detector: FCL
      pipeline: ompl
      planner: RRTConnect
      request: jc
      robot: panda
      scene: empty
    metrics:
      clearance: [inf]
      correct: [1]
      length: [5.5403108596801758]
      smoothness: [6.5978969681883682e-16]
      success: [1]
      time: [0.025614999234676361]
      waypoints: [35]
  - query:
      collision_detector: Bullet
      pipeline: ompl
      planner: RRTConnect
      request: jc
      robot: panda
      scene: empty
    metrics:
      clearance: [inf]
      correct: [1]
      length: [5.5403108596801758]
      smoothness: [6.5978969681883682e-16]
      success: [1]
      time: [0.048869535326957703]
      waypoints: [35]

```